### PR TITLE
Remove hypercore-archiver

### DIFF
--- a/src/hypermerge/hello.js
+++ b/src/hypermerge/hello.js
@@ -1,0 +1,26 @@
+const Multicore = require('./Multicore')
+
+
+const mc = new Multicore('./data/testing')
+const mc2 = new Multicore('./data/testing2')
+
+mc.ready(() => {
+  mc.joinSwarm()
+
+  const feed = mc.hypercore()
+  feed.append('hello world')
+
+  feed.ready(() => {
+    const key = feed.key.toString('hex')
+
+    console.log('feedkey:', key)
+
+    mc2.ready(() => {
+      mc2.joinSwarm()
+      mc2.hypercore(key).get(0, (err, str) => {
+        console.log('mc2 get:', str)
+      })
+    })
+  })
+})
+

--- a/src/hypermerge/index.js
+++ b/src/hypermerge/index.js
@@ -397,7 +397,7 @@ class Hypermerge extends EventEmitter {
   _feed(actorId = null) {
     const key = actorId ? Buffer.from(actorId, 'hex') : null
     log('_feed', actorId)
-    return this.core.createFeed(key)
+    return this.core.hypercore(key)
   }
 
   // Finds or creates, and returns, a tracked feed. This means that updates to
@@ -769,7 +769,7 @@ class Hypermerge extends EventEmitter {
     log('_onMulticoreReady')
 
     const actorIds =
-      Object.values(this.core.archiver.feeds)
+      Object.values(this.core.feeds)
         .map(feed => feed.key.toString('hex'))
 
     this._initFeeds(actorIds)

--- a/src/hypermerge/multicore.js
+++ b/src/hypermerge/multicore.js
@@ -1,8 +1,11 @@
 const { EventEmitter } = require('events')
 const HypercoreProtocol = require('hypercore-protocol')
-const HypercoreArchiver = require('hypercore-archiver')
+const raf = require('random-access-file')
+const path = require('path')
 const Hypercore = require('hypercore')
 const crypto = require('hypercore/lib/crypto')
+const discoverySwarm = require('discovery-swarm')
+const swarmDefaults = require('dat-swarm-defaults')
 const toBuffer = require('to-buffer')
 const Debug = require('debug')
 
@@ -14,16 +17,33 @@ const log = Debug('hypermerge:multicore')
 // * appends change (just adds?) to a feed (where exactly?) for each tracked core
 // * replication??
 class Multicore extends EventEmitter {
-  constructor(storage) {
+  constructor(storage, { port } = {}) {
     super()
     log('constructor', storage)
 
-    this.archiver = new HypercoreArchiver(storage)
+    this.port = port
+    this.storage = defaultStorage(storage)
+
     this.isReady = false
-    const self = this
-    this.archiver.on('ready', () => {
-      self.isReady = true
-      self.emit('ready')
+    this.feeds = {} // dk -> Feed
+    this.index = {
+      discoveryKeys: {} // discoveryKey -> Boolean
+    }
+
+    readAll(this.storage.index(), (err, buff) => {
+      if (err) {
+        console.error('could not read index', err)
+        // TODO emit error
+        return
+      }
+
+      if (buff.length !== 0) {
+        this.index = JSON.parse(buff)
+        // TODO catch parsing errors and emit 'error'
+      }
+
+      this.isReady = true
+      this.emit('ready')
     })
   }
 
@@ -35,9 +55,9 @@ class Multicore extends EventEmitter {
     }
   }
 
-  createFeed(key, opts = {}) {
+  hypercore(key, opts = {}) {
     this._ensureReady()
-    log('createFeed', key && key.toString('hex'))
+    log('hypercore', key && key.toString('hex'))
 
     // Create a key pair if we're making a feed from scratch.
     if (!key) {
@@ -47,37 +67,66 @@ class Multicore extends EventEmitter {
     }
 
     const dk = Hypercore.discoveryKey(toBuffer(key, 'hex')).toString('hex')
+    this._addDiscoveryKey(dk)
 
-    if (this.archiver.feeds[dk]) {
-      return this.archiver.feeds[dk]
+    return this.hypercoreFromDiscoveryKey(dk, opts)
+  }
+
+  hypercoreFromDiscoveryKey(dk, opts = {}) {
+    if (this.feeds[dk]) {
+      return this.feeds[dk]
     }
 
-    opts.sparse = this.archiver.sparse
-    const feed = Hypercore(this._feedStorage(key), key, opts)
-    this.archiver.feeds[dk] = feed
+    if (!this.index.discoveryKeys[dk]) {
+      throw new Error('Trying to open discoveryKey for feed without a publicKey')
+    }
 
-    this.archiver.changes.append({ type: 'add', key: key.toString('hex') })
-    this.archiver.emit('add', feed)
+    const feed = Hypercore(this._feedStorage(dk), opts)
+    this.feeds[dk] = feed
 
     return feed
   }
 
-  // Returns a RandomAccessStorage function for the given public feed key.
-  // Uses git-style ab/cd/* namespacing and passes that to the underlying
-  // storage function given in the constructor.
-  _feedStorage(key) {
-    const dk = Hypercore.discoveryKey(key).toString('hex')
-    const prefix = `${dk.slice(0, 2)}/${dk.slice(2, 4)}/${dk.slice(4)}/`
-    return (name) => this.archiver.storage.feeds(prefix + name)
+  joinSwarm(opts = {}) {
+    this._ensureReady()
+
+    log('joinSwarm')
+
+    this.swarm = discoverySwarm(swarmDefaults(Object.assign({
+      port: this.port,
+      hash: false,
+      encrypt: true,
+      stream: info => this.replicate(info)
+    }, opts)))
+
+    Object.keys(this.index.discoveryKeys)
+      .forEach(dk => {
+        log('swarm existing dk', dk)
+        this.swarm.join(toBuffer(dk, 'hex'))
+      })
+
+    this.swarm.listen(this.port)
+
+    this.swarm.once('error', err => {
+      log('joinSwarm.error', err)
+      this.swarm.listen()
+    })
+
+    return this
   }
 
-  replicate(opts) {
+  // Returns a RandomAccessStorage function for the given hex discovery key.
+  // Uses git-style ab/cd/* namespacing and passes that to the underlying
+  // storage function given in the constructor.
+  _feedStorage(dk) {
+    const prefix = `${dk.slice(0, 2)}/${dk.slice(2, 4)}/${dk.slice(4)}/`
+    return name => this.storage.feeds(prefix + name)
+  }
+
+
+  replicate(opts = {}) {
     this._ensureReady()
     log('replicate')
-
-    if (!opts) {
-      opts = {}
-    }
 
     if (opts.discoveryKey) {
       opts.discoveryKey = toBuffer(opts.discoveryKey, 'hex')
@@ -87,98 +136,110 @@ class Multicore extends EventEmitter {
       opts.discoveryKey = Hypercore.discoveryKey(toBuffer(opts.key, 'hex'))
     }
 
-    const { archiver } = this
-
     const stream = HypercoreProtocol({
       live: true,
-      id: archiver.changes.id,
+      // TODO store a peer id in the multicore.json and set here `id: this.index.id`
       encrypt: opts.encrypt,
-      extensions: ['hypermerge']
+      extensions: ['hypermerge'] // TODO replace this with 'multicore' and pull messaging into here
     })
 
-    stream.on('feed', add)
-    if (opts.channel || opts.discoveryKey) {
-      add(opts.channel || opts.discoveryKey)
+    stream.on('feed', this._feedRequested(stream))
+
+    if (!opts.channel) {
+      // TODO figure out when channel can be missing
+      throw new Error('opts.channel is missing and i dont\' know why')
     }
 
-    function add(dk) {
-      const hex = dk.toString('hex')
-      log('replicate.add', hex)
-
-      if (stream.destroyed) {
-        return
-      }
-
-      const changesHex = archiver.changes.discoveryKey.toString('hex')
-
-      const archive = archiver.archives[hex]
-      if (archive) {
-        onarchive()
-        return
-      }
-
-      const feed = changesHex === hex ? archiver.changes : archiver.feeds[hex]
-      if (feed) {
-        onfeed()
-      }
-
-      function onarchive() {
-        log('replicate.onarchive')
-
-        archive.metadata.replicate({
-          stream,
-          live: true
-        })
-        archive.content.replicate({
-          stream,
-          live: true
-        })
-      }
-
-      function onfeed() {
-        log('replicate.onfeed')
-
-        if (stream.destroyed) {
-          return
-        }
-
-        stream.on('close', onclose)
-        stream.on('end', onclose)
-
-        feed.on('_archive', onarchive)
-        feed.replicate({
-          stream,
-          live: true
-        })
-
-        function onclose() {
-          log('replicate.onclose')
-          feed.removeListener('_archive', onarchive)
-        }
-
-        function onarchive() {
-          log('replicate.onarchive')
-          if (stream.destroyed) {
-            return
-          }
-
-          const { content } = archiver.archives[hex]
-          content.replicate({
-            stream,
-            live: true
-          })
-        }
-      }
-    }
+    this._addDiscoveryKey(opts.channel)
 
     return stream
   }
 
   _ensureReady() {
     if (!this.isReady) {
-      throw new Error('The HypercoreArchiver instance is not ready yet. Use .on("ready") first.')
+      throw new Error('The MultiCore instance is not ready yet. Use .ready(cb) first.')
     }
+  }
+
+  _feedRequested(stream) {
+    return discoveryKey => {
+      const dk = discoveryKey.toString('hex')
+      log('_feedRequested', dk)
+
+      if (stream.destroyed) {
+        return
+      }
+
+      if (this.index.discoverykeys[dk]) {
+        this._replicateFeed(stream, this.hypercoreFromDiscoveryKey(dk))
+      } else {
+        throw new Error(`Unkown feed requested by peer: ${dk}`) // TODO what should we do in this situation?
+      }
+    }
+  }
+
+  _replicateFeed(stream, feed) {
+    log('_replicateFeed')
+
+    feed.replicate({
+      stream,
+      live: true
+    })
+  }
+
+  // Index related thing below
+
+  _addDiscoveryKey(dk) {
+    if (!this.index.discoveryKeys[dk]) {
+      this.index.discoveryKeys[dk] = true
+
+      if (this.swarm) {
+        log('swarm new dk', dk)
+        this.swarm.join(toBuffer(dk, 'hex'))
+      }
+
+      this._writeIndex()
+    }
+  }
+
+  _writeIndex() {
+    // TODO write index to disk
   }
 }
 
 module.exports = Multicore
+
+function defaultStorage(st) {
+  if (typeof st === 'string') {
+    return {
+      index() {
+        return raf(path.join(st, 'multicore.json'))
+      },
+      feeds(name) {
+        return raf(path.join(st, 'feeds', name))
+      }
+    }
+  }
+
+  if (typeof st === 'function') {
+    return {
+      index() {
+        return st('multicore.json')
+      },
+      feeds(name) {
+        return st(`feeds/${name}`)
+      }
+    }
+  }
+
+  return st
+}
+
+function readAll(st, cb) {
+  st.stat((err, stat) => {
+    if (err) {
+      return cb(null, Buffer.from(''))
+    }
+    st.read(0, stat.size, cb)
+  })
+}

--- a/src/hypermerge/multicore.js
+++ b/src/hypermerge/multicore.js
@@ -155,13 +155,11 @@ class Multicore extends EventEmitter {
 
     stream.on('feed', this._feedRequested(stream))
 
-    console.log('channel:', opts.channel)
-    if (!opts.channel) {
+    if (opts.channel) {
+      this._addDiscoveryKey(opts.channel)
       // TODO figure out when channel can be missing
-      throw new Error('opts.channel is missing and i dont\' know why')
     }
 
-    this._addDiscoveryKey(opts.channel)
 
     return stream
   }


### PR DESCRIPTION
Hypercore-archiver really likes to open all the hypercores it hears about. This is problematic if you have many thousands of them.

This isn't my patch, it's Jeff and Mark's, but I'm opening a PR to coordinate conversation. I've rebased it against an 0.8-alpha1 era PushPin and fixed a couple errors that prevented it from loading existing boards.

As of this writing, it does not actually replicate.