### PR TITLE
handleClickOutside ignores invitations icon

### DIFF
--- a/src/components/workspace/board-title-input.jsx
+++ b/src/components/workspace/board-title-input.jsx
@@ -50,6 +50,11 @@ export default class BoardTitleInput extends React.PureComponent {
     }
   }
 
+  handleBlur = (e) => {
+    this.props.onCancel()
+    this.setState({ newTitle: null })
+  }
+
   handleChange = (e) => {
     this.setState({ newTitle: e.target.value })
   }
@@ -73,6 +78,7 @@ export default class BoardTitleInput extends React.PureComponent {
         type="text"
         className={titleInputClasses}
         value={title}
+        onBlur={this.handleBlur}
         onChange={this.handleChange}
         onKeyDown={this.handleKey}
         onClick={this.props.onClick}

--- a/src/components/workspace/board-title.jsx
+++ b/src/components/workspace/board-title.jsx
@@ -160,7 +160,12 @@ export default class BoardTitle extends React.PureComponent {
   }
 
   handleClickOutside = (e) => {
-    if (e.target.className === 'fa fa-envelope') {
+    if (this.state.activeTitleEditor) {
+      return
+    }
+
+    if (e.target.className === 'fa fa-envelope' ||
+      e.target.className === 'BoardTitle__actionBar') {
       return
     }
 
@@ -178,10 +183,12 @@ export default class BoardTitle extends React.PureComponent {
     if (!this.state.activeTitleEditor) {
       this.activateOmnibox()
     }
+    e.stopPropagation()
   }
 
-  activateTitleEditor = () => {
+  activateTitleEditor = (e) => {
     this.setState({ activeTitleEditor: true })
+    e.stopPropagation()
   }
 
   updateTitle = (value) => {
@@ -259,16 +266,15 @@ export default class BoardTitle extends React.PureComponent {
       }
 
       inputBar = (
-        <div className="BoardTitle__actionBar">
+        <div className="BoardTitle__actionBar" onClick={this.handleTitleClick}>
           <div className="BoardTitle__actionBar__left">
-            <i className={invitationsClasses} onClick={this.activateOmnibox} />
+            <i className={invitationsClasses} />
           </div>
           <BoardTitleInput
             active={this.state.activeTitleEditor}
             onSubmit={this.updateTitle}
             onCancel={this.cancelTitleEdit}
             defaultValue={this.state.board && this.state.board.title || ''}
-            onClick={this.activateOmnibox}
           />
           <div className="BoardTitle__actionBar__right">
             <i className="fa fa-edit" onClick={this.activateTitleEditor} />

--- a/src/components/workspace/board-title.jsx
+++ b/src/components/workspace/board-title.jsx
@@ -160,6 +160,10 @@ export default class BoardTitle extends React.PureComponent {
   }
 
   handleClickOutside = (e) => {
+    if (e.target.className === 'fa fa-envelope') {
+      return
+    }
+
     if (e.target.className !== 'TitleBar__titleText') {
       this.deactivateOmnibox()
     }


### PR DESCRIPTION
Ideally, the invitations click handler could just do `e.stopPropagation()`, but that doesn't work because `handleClickOutside` is being directly set on the document and the invitations handler goes through React's simulated events.

Didn't want to spend too much time on this so I just went with the easier solution where we check to see if the invitations icon was clicked and ignore it.