### PR TITLE
Add pushpin URI to hacking doc

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -39,6 +39,14 @@ Open `./src/components/thread.jsx` in your preferred editor.
 You can see that the Thread code looks mostly like a simple React component. That's because it is! The Toggle component gets it state from a Hypermerge document. The document is available inside the component by creating a "handle" to the document from `hypermergeUrl` property. 
 
 
+## Pushpin URIs
+
+Pushpin establishes a `pushpin:` protocol for URIs that can be shared. Underneath the hood, a `pushpin:` URI is translated to a `hypermerge:` URI. Let's take a look at the parts:
+
+![Pushpin URI](./docs/pushpin-uri.svg)
+
+The content type is used to determine what React component should be used to render the document content. Meanwhile, the `docId` portion is passed on to hypermerge by prefixing its protocol, becoming: `hypermerge:/5vmhLfwX3J2332pZUtA9QWi1Pu5Dvux9E9xVYWPnnTKc`. The last portion of the pushpin URI, the "CRC" is used as a check on the preceding portion so that if anything is mistyped the app can respond immediately with suggestions to the user rather than waiting and finding out after a long, unsuccessful attempt that there are no peers sharing data about the so-called docId.
+
 ## Hypermerge Document
 
 A Hypermerge document is a live, versioned data structure. You can read its contents, change it, and subscribe to it to hear its changes. Every change made to a Hypermerge document is captured and distributed to other instances of the document whether they are within your local document or another user's copy anywhere else in the world.

--- a/docs/pushpin-uri.svg
+++ b/docs/pushpin-uri.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 660 84"
+     style="background-color: #eee; padding: 10px">
+  <style>
+    /* <![CDATA[ */
+    .code {
+      font-family: monospace;
+      font-size: 16px;
+    }
+    /* ]]> */
+  </style>
+  <text class="code" x="0" y="18"><tspan>pushpin://</tspan><tspan fill="#7f7fff">board/</tspan><tspan fill="#007fff">5vmhLfwX3J2332pZUtA9QWi1Pu5Dvux9E9xVYWPnnTKc</tspan><tspan>/29J</tspan></text>
+  <path stroke="#93a0b6" strokewidth="1" fill="none" d="M0.5,24 v4.5 h90 v-4.5 m0,4.5 h60 v-4.5 m0,4.5 h425 v-4.5 m0,4.5 h40 v-4.5"></path>
+  <text y="44" text-anchor="middle"><tspan x="40">protocol</tspan><tspan x="40" dy="1.2em">identifier</tspan></text>
+  <text y="44" text-anchor="middle"><tspan x="125">content type</tspan></text>
+  <text y="44" text-anchor="middle"><tspan x="365">docId</tspan><tspan x="365" dy="1.2em">(base58)</tspan></text>
+  <text y="44" text-anchor="middle"><tspan x="595">CRC</tspan></text>
+</svg>


### PR DESCRIPTION
Improve documentation around `pushpin:` protocol and associated URI