### PR TITLE
move presence to workspace so it works on all cards

### DIFF
--- a/src/renderer/components/workspace/workspace.js
+++ b/src/renderer/components/workspace/workspace.js
@@ -88,6 +88,9 @@ To create links to boards or contacts, drag them from the title bar or the omnib
   componentWillMount = () => this.refreshHandle(this.props.hypermergeUrl)
   componentWillUnmount = () => {
     this.handle.close()
+    if (this.state.selfId) {
+      this.heartbeatNotifyDeparture(this.state.selfId)
+    }
     clearInterval(this.timerId)
   }
 
@@ -105,10 +108,40 @@ To create links to boards or contacts, drag them from the title bar or the omnib
     this.handle.subscribe((doc) => this.onChange(doc))
   }
 
+  onChange = (doc) => {
+    this.setState({ ...doc })
+    this.refreshSelfHeartbeat(doc)
+    this.refreshCurrentDocHandle(doc)
+  }
+
+  // The workspace takes on two responsibilities around presence.
+  // First, it posts on the self-contact ID that we're online.
+  // This means any avatar anywhere will have a colored ring around it
+  // if that user is online.
+  refreshSelfHeartbeat = (doc) => {
+    const selfHandle = window.repo.open(doc.selfId)
+
+    if (!this.selfTimerId) {
+      selfHandle.message('heartbeat')
+      this.selfTimerId = setInterval(() => {
+        selfHandle.message('heartbeat')
+      }, 1000) // send a heartbeat every 5s
+    }
+  }
+
+  // Second, it posts a presence heartbeat on the document currently
+  // considered to be open, allowing any kind of card to render a list of
+  // "present" folks.
+  // Any time the document changes, we throw away the old handle and
+  // make a new one for the new document.
+  // NB: The current implementation doesn't have any caching of messages,
+  //     so "present" avatars will have to wait for a second heartbeat to arrive
+  //     before appearing present since the first one will have passed in causing
+  //     them to render...
   refreshCurrentDocHandle = ({ selfId, currentDocUrl }) => {
     if (this.currentDocHandle) {
       this.currentDocHandle.close()
-      // TODO: departure?
+      this.heartbeatNotifyDeparture(selfId)
     }
     const { hypermergeUrl } = parseDocumentLink(currentDocUrl)
     this.currentDocHandle = window.repo.open(hypermergeUrl)
@@ -117,25 +150,13 @@ To create links to boards or contacts, drag them from the title bar or the omnib
       this.currentDocHandle.message({ contact: selfId, heartbeat: true })
       this.currentDocTimerId = setInterval(() => {
         this.currentDocHandle.message({ contact: selfId, heartbeat: true })
-      }, 5000) // send a heartbeat every 5s
+      }, 1000) // send a heartbeat every 5s
     }
   }
 
-  onChange = (doc) => {
-    this.setState({ ...doc })
-    this.refreshSelfHeartbeat(doc)
-    this.refreshCurrentDocHandle(doc)
-  }
-
-  refreshSelfHeartbeat = (doc) => {
-    const selfHandle = window.repo.open(doc.selfId)
-
-    if (!this.selfTimerId) {
-      selfHandle.message('heartbeat')
-      this.selfTimerId = setInterval(() => {
-        selfHandle.message('heartbeat')
-      }, 5000) // send a heartbeat every 5s
-    }
+  heartbeatNotifyDeparture = (selfId) => {
+    // notify peers on the current board that we're departing
+    this.currentDocHandle.message({ contact: selfId, departing: true })
   }
 
   openDoc = (docUrl) => {


### PR DESCRIPTION
Still a few kinks to work out here:
 * presence / messages aren't cached so each avatar implementation has to wait for a message to arrive
 * we handle broadcasting to selfId and to the current document with different message formats
 * not quite sure how this will fit in with other design elements in the titlebar