### PR TITLE
disable webSecurity to bypass cors restrictions

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -21,6 +21,7 @@ const createWindow = async () => {
     height: 1000,
     webPreferences: {
       nodeIntegration: true,
+      webSecurity: false
     }
   })
 


### PR DESCRIPTION
This is probably not a great idea for this reason: https://github.com/electron/electron/blob/master/docs/tutorial/security.md#5-do-not-disable-websecurity

Still, I don't really know of another way to allow requesting web content. I have found the whole fetch() permissions saga deeply infuriating in the past.