### PR TITLE
[wip] HTML5 drag & drop + dragging out of files

### DIFF
--- a/src/renderer/components/content-types/board/Board.tsx
+++ b/src/renderer/components/content-types/board/Board.tsx
@@ -1,26 +1,28 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
+import React, { useRef, useState, useCallback, memo, useMemo } from 'react'
 import Debug from 'debug'
-import uuid from 'uuid/v4'
-
-import { Handle } from 'hypermerge'
 import { ContextMenuTrigger } from 'react-contextmenu'
-import { ContentProps } from '../../Content'
+
 import ContentTypes from '../../../ContentTypes'
 import * as ImportData from '../../../ImportData'
-import { parseDocumentLink, PushpinUrl } from '../../../ShareLink'
-import { BoardDoc } from '.'
-import BoardCard from './BoardCard'
+import { PushpinUrl } from '../../../ShareLink'
+import { ContentProps } from '../../Content'
+import { BoardDoc, CardId } from '.'
+import BoardCard, { BoardCardAction } from './BoardCard'
 import BoardContextMenu from './BoardContextMenu'
 import './Board.css'
+import { Position, Dimension, gridOffset, GRID_SIZE } from './BoardGrid'
+import { useSelection } from './BoardSelection'
 import {
-  Position,
-  Dimension,
-  gridOffset,
-  gridCellsToPixels,
-  snapDimensionToGrid,
-  snapPositionToGrid,
-} from './BoardGrid'
+  deleteCards,
+  addCardForContent,
+  moveCardsBy,
+  cardResized,
+  changeBackgroundColor,
+  BoardDocManipulationAction,
+} from './BoardDocManipulation'
+
+import { BOARD_CARD_DRAG_ORIGIN } from '../../../constants'
+import { useDocumentReducer } from '../../../Hooks'
 
 const log = Debug('pushpin:board')
 
@@ -45,69 +47,13 @@ export const BOARD_COLORS = {
   BLACK: '#2b2b2b',
 }
 
-const CARD_MIN_WIDTH = 81
-const CARD_MIN_HEIGHT = 41
-
-const BOARD_WIDTH = 3600
-const BOARD_HEIGHT = 1800
+export const BOARD_WIDTH = 3600
+export const BOARD_HEIGHT = 1800
 
 // We don't want to compute a new array in every render.
 const BOARD_COLOR_VALUES = Object.values(BOARD_COLORS)
 
-const draggableCards = (cards, selected, card) => {
-  if (selected.length > 0 && selected.find((id) => id === card.id)) {
-    return selected.map((id) => cards[id])
-  }
-  return [card]
-}
-
-interface State {
-  selected: any[]
-  remoteSelection: { [contact: string]: string[] }
-  contextMenuPosition?: Position
-  tracking: { [cardId: string]: TrackingEntry }
-  doc?: BoardDoc
-}
-
-export enum DragType {
-  MOVING,
-  RESIZING,
-  NOT_DRAGGING,
-}
-
-export interface MoveTracking {
-  dragType: DragType.MOVING
-  moveX: number
-  moveY: number
-  slackX: number
-  slackY: number
-}
-
-export interface ResizeTracking {
-  dragType: DragType.RESIZING
-  slackWidth: number
-  slackHeight: number
-  resizeWidth: number
-  resizeHeight: number
-  minWidth: number
-  minHeight: number
-  maxWidth: number
-  maxHeight: number
-}
-
-export interface NotDraggingTracking {
-  dragType: DragType.NOT_DRAGGING
-}
-
-export function isMoving(tracking): tracking is MoveTracking {
-  return tracking.dragType === DragType.MOVING
-}
-
-export function isResizing(tracking): tracking is ResizeTracking {
-  return tracking.dragType === DragType.RESIZING
-}
-
-export type TrackingEntry = MoveTracking | ResizeTracking | NotDraggingTracking
+export type BoardAction = BoardDocManipulationAction | BoardCardAction
 
 interface CardArgs {
   position: Position
@@ -118,577 +64,252 @@ export interface AddCardArgs extends CardArgs {
   url: PushpinUrl
 }
 
-export default class Board extends React.PureComponent<ContentProps, State> {
-  private handle?: Handle<BoardDoc>
+function Board(props: ContentProps) {
+  const boardRef = useRef<HTMLDivElement>(null)
+  const { selection, selectOnly, selectToggle, selectNone } = useSelection<CardId>()
+  const [distance, setDistance] = useState<Position>({ x: 0, y: 0 })
 
-  private boardRef = React.createRef<HTMLDivElement>()
-  private cardRefs: Map<string, HTMLDivElement> = new Map<string, HTMLDivElement>()
-  private finishedDrag: boolean = false
-  private tracking: { [cardId: string]: TrackingEntry } = {}
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // this event can be consumed by a card if it wants to keep control of backspace
+      // for example, see text-content.jsx onKeyDown
+      if (e.key === 'Backspace') {
+        dispatch({ type: 'DeleteCards', selection })
+      }
+    },
+    [selection]
+  )
 
-  private heartbeatTimerId?: NodeJS.Timer
-  private contactHeartbeatTimerId: Map<string, NodeJS.Timer> = new Map<string, NodeJS.Timer>()
-
-  state: State = {
-    remoteSelection: {},
-    selected: [],
-    tracking: {},
-  }
-
-  componentWillMount = () => {
-    this.handle = window.repo.open(this.props.hypermergeUrl)
-    this.handle.subscribe((doc) => this.onChange(doc))
-    this.handle.subscribeMessage((msg) => this.onMessage(msg))
-  }
-  componentWillUnmount = () => {
-    this.handle && this.handle.close()
-    this.heartbeatTimerId && clearInterval(this.heartbeatTimerId)
-  }
-
-  onChange = (doc) => {
-    this.setState({ doc })
-  }
-
-  onKeyDown = (e) => {
-    // this event can be consumed by a card if it wants to keep control of backspace
-    // for example, see text-content.jsx onKeyDown
-    if (e.key === 'Backspace') {
-      this.deleteCard(this.state.selected)
-    }
-  }
-
-  onClick = (e) => {
+  const onClick = useCallback((e: React.MouseEvent) => {
     log('onClick')
-    this.selectNone()
+    selectNone()
+  }, [])
+
+  const [doc, dispatch] = useDocumentReducer<BoardDoc, BoardAction>(
+    props.hypermergeUrl,
+    (doc, action) => {
+      switch (action.type) {
+        // board actions
+        case 'AddCardForContent':
+          addAndSelectCard(doc, action.position, action.url, action.selectOnly)
+          break
+        case 'ChangeBackgroundColor':
+          changeBackgroundColor(doc, action.color)
+          break
+        case 'MoveCardsBy':
+          moveCardsBy(doc, action.selection, action.distance)
+          break
+        case 'DeleteCards':
+          deleteCards(doc, selection)
+          break
+
+        // card actions
+        case 'CardDragging':
+          setDistance(action.distance)
+          break
+        case 'CardResized':
+          cardResized(doc, action.cardId, action.dimension)
+          break
+        case 'CardClicked':
+          onCardClicked(action.cardId, action.event)
+          break
+        case 'CardDoubleClicked':
+          onCardDoubleClicked(doc, action.cardId, action.event)
+          break
+      }
+    }
+  )
+
+  // xxx: this one is tricky because it feels like it should be in boardDocManipulation
+  // but there isn't really a good way to get the cardId back from the dispatch
+  function addAndSelectCard(
+    doc: BoardDoc,
+    position: Position,
+    url: PushpinUrl,
+    shouldSelect?: boolean
+  ) {
+    const cardId = addCardForContent(doc, { position, url })
+    if (shouldSelect) {
+      selectOnly(cardId)
+    }
   }
 
-  onCardClicked = (card, e) => {
-    if (this.finishedDrag) {
-      // this is the end of a resize / move event, don't change selection
-      this.finishedDrag = false
-      e.stopPropagation()
-      return
-    }
-
+  const onCardClicked = (id: CardId, e: React.MouseEvent) => {
     if (e.ctrlKey || e.shiftKey) {
-      this.selectToggle(card.id)
+      selectToggle(id)
     } else {
       // otherwise we don't have shift/ctrl, so just set selection to this
-      this.selectOnly(card.id)
+      selectOnly(id)
     }
     e.stopPropagation()
   }
 
-  onCardDoubleClicked = (card, e) => {
-    window.location = card.url
+  const onCardDoubleClicked = (doc: BoardDoc, id: CardId, e: React.MouseEvent) => {
+    const card = doc.cards[id]
+    if (card && card.url) {
+      window.location.href = card.url as string
+    }
     e.stopPropagation()
   }
 
-  onDoubleClick = (e) => {
-    log('onDoubleClick')
+  const onDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      log('onDoubleClick')
 
-    // guard against a missing boardRef
-    if (!this.boardRef.current) {
-      return
-    }
-
-    const position = {
-      x: e.pageX - this.boardRef.current.offsetLeft,
-      y: e.pageY - this.boardRef.current.offsetTop,
-    }
-
-    ContentTypes.create('text', { text: '' }, (url) => {
-      const cardId = this.addCardForContent({ position, url })
-      this.selectOnly(cardId)
-    })
-  }
-
-  onDragOver = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-  }
-
-  onDrop = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-    const { pageX, pageY } = e
-
-    if (!this.boardRef.current) {
-      return
-    }
-    const position = {
-      x: pageX - this.boardRef.current.offsetLeft,
-      y: pageY - this.boardRef.current.offsetTop,
-    }
-
-    ImportData.importDataTransfer(e.dataTransfer, (url, i) => {
-      const offsetPosition = gridOffset(position, i)
-      this.addCardForContent({ position: offsetPosition, url })
-    })
-  }
-
-  onPaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
-    log('onPaste')
-    e.preventDefault()
-    e.stopPropagation()
-
-    if (!e.clipboardData) {
-      return
-    }
-
-    /* We can't get the mouse position on a paste event,
-     so we ask the window for the current pageX/Y offsets and just stick the new card
-     100px in from there. (The new React might support this through pointer events.) */
-    const position = {
-      x: window.pageXOffset + 100,
-      y: window.pageYOffset + 100,
-    }
-
-    ImportData.importDataTransfer(e.clipboardData, (url, i) => {
-      const offsetPosition = gridOffset(position, i)
-      this.addCardForContent({ position: offsetPosition, url })
-    })
-  }
-
-  onFilesOpened = (e: React.FormEvent<HTMLInputElement>) => {
-    // e.target.files
-  }
-
-  addCardForContent = ({ position, dimension, url }: AddCardArgs) => {
-    const id = uuid()
-
-    const { type } = parseDocumentLink(url)
-    const { component = {} } = ContentTypes.lookup({ type, context: 'board' }) as any
-
-    if (!dimension)
-      dimension = {
-        width: gridCellsToPixels(component.defaultWidth),
-        height: gridCellsToPixels(component.defaultHeight),
-      }
-
-    this.handle &&
-      this.handle.change((b) => {
-        const { x, y } = snapPositionToGrid(position)
-        const { width, height } = snapDimensionToGrid(dimension)
-        const newCard = {
-          id,
-          url,
-          x,
-          y,
-          width,
-          height,
-        }
-        b.cards[id] = newCard
-      })
-
-    return id
-  }
-
-  deleteCard = (id) => {
-    // allow either an array or a single card to be passed in
-    if (id.constructor !== Array) {
-      id = [id]
-    }
-
-    this.handle &&
-      this.handle.change((b) => {
-        id.forEach((id) => delete b.cards[id])
-      })
-  }
-
-  changeTitle = (title) => {
-    log('changeTitle')
-    this.handle &&
-      this.handle.change((b) => {
-        b.title = title
-      })
-  }
-
-  changeBackgroundColor = (color) => {
-    log('changeBackgroundColor')
-    this.handle &&
-      this.handle.change((b) => {
-        b.backgroundColor = color.hex
-      })
-  }
-
-  /**
-   *
-   * Card placement / manipulation actions
-   *
-   */
-
-  cardMoved = ({ id, position }) => {
-    if (!(this.state.doc && this.state.doc.cards)) {
-      return
-    }
-
-    // This gets called when uniquely selecting a card, so avoid a document
-    // change if in fact the card hasn't moved mod snapping.
-    const snapPosition = snapPositionToGrid(position)
-    const cardPosition = { x: this.state.doc.cards[id].x, y: this.state.doc.cards[id].y }
-    if (snapPosition.x === cardPosition.x && snapPosition.y === cardPosition.y) {
-      return
-    }
-    this.handle &&
-      this.handle.change((b) => {
-        const card = b.cards[id]
-        card.x = snapPosition.x
-        card.y = snapPosition.y
-      })
-  }
-
-  cardResized = ({ id, dimension }) => {
-    if (!(this.state.doc && this.state.doc.cards)) {
-      return
-    }
-
-    // This gets called when we click the drag corner of a card, so avoid a
-    // document change if in fact the card won't resize mod snapping.
-    const snapDimension = snapDimensionToGrid(dimension)
-    const cardDimension = {
-      width: this.state.doc.cards[id].width,
-      height: this.state.doc.cards[id].height,
-    }
-    if (
-      snapDimension.width === cardDimension.width &&
-      snapDimension.height === cardDimension.height
-    ) {
-      return
-    }
-    this.handle &&
-      this.handle.change((b) => {
-        const card = b.cards[id]
-        card.width = snapDimension.width
-        card.height = snapDimension.height
-      })
-  }
-
-  effectDrag = (card, tracking: TrackingEntry, { deltaX, deltaY }) => {
-    if (deltaX === 0 && deltaY === 0) {
-      return
-    }
-
-    if (isMoving(tracking)) {
-      // First guess at change in location given mouse movements.
-      const preClampX = tracking.moveX + deltaX
-      const preClampY = tracking.moveY + deltaY
-
-      // Add slack to the values used to calculate bound position. This will
-      // ensure that if we start removing slack, the element won't react to
-      // it right away until it's been completely removed.
-      let newX = preClampX + tracking.slackX
-      let newY = preClampY + tracking.slackY
-
-      // Clamp to ensure card doesn't move beyond the board.
-      newX = Math.max(newX, 0)
-      newX = Math.min(newX, BOARD_WIDTH - card.width)
-      tracking.moveX = newX
-      newY = Math.max(newY, 0)
-      newY = Math.min(newY, BOARD_HEIGHT - card.height)
-      tracking.moveY = newY
-
-      // If the numbers changed, we must have introduced some slack.
-      // Record it for the next iteration.
-      tracking.slackX = tracking.slackX + preClampX - newX
-      tracking.slackY = tracking.slackY + preClampY - newY
-    }
-
-    if (isResizing(tracking)) {
-      // First guess at change in dimensions given mouse movements.
-      const preClampWidth = tracking.resizeWidth + deltaX
-      const preClampHeight = tracking.resizeHeight + deltaY
-
-      if (preClampWidth + card.x > BOARD_WIDTH || preClampHeight + card.y > BOARD_HEIGHT) {
+      // guard against a missing boardRef
+      if (!boardRef.current) {
         return
       }
 
-      // Add slack to the values used to calculate bound position. This will
-      // ensure that if we start removing slack, the element won't react to
-      // it right away until it's been completely removed.
-      let newWidth = preClampWidth + tracking.slackWidth
-      let newHeight = preClampHeight + tracking.slackHeight
-
-      // Clamp to ensure card doesn't resize beyond the board or min dimensions.
-      newWidth = Math.max(tracking.minWidth, newWidth)
-      newWidth = Math.min(tracking.maxWidth, newWidth)
-      newWidth = Math.min(BOARD_WIDTH - card.x, newWidth)
-      tracking.resizeWidth = newWidth
-      newHeight = Math.max(tracking.minHeight, newHeight)
-      newHeight = Math.min(tracking.maxHeight, newHeight)
-      newHeight = Math.min(BOARD_HEIGHT - card.y, newHeight)
-      tracking.resizeHeight = newHeight
-
-      // If the numbers changed, we must have introduced some slack.
-      // Record it for the next iteration.
-      tracking.slackWidth = tracking.slackWidth + preClampWidth - newWidth
-      tracking.slackHeight = tracking.slackHeight + preClampHeight - newHeight
-    }
-  }
-
-  setCardRef = (id, node) => {
-    this.cardRefs[id] = node
-  }
-
-  onDrag = (card, e, d) => {
-    if (!(this.state.doc && this.state.doc.cards)) {
-      return
-    }
-    log('onDrag')
-    const tracking = this.tracking[card.id]
-
-    // If we haven't started tracking this drag, initialize tracking
-    if (!tracking) {
-      const resizing = e.target.className === 'BoardCard-resizeHandle'
-      const moving = !resizing
-
-      if (moving) {
-        const cards = draggableCards(this.state.doc.cards, this.state.selected, card)
-
-        cards.forEach((c) => {
-          this.tracking[c.id] = {
-            dragType: DragType.MOVING,
-            moveX: c.x,
-            moveY: c.y,
-            slackX: 0,
-            slackY: 0,
-          }
-        })
+      const position = {
+        x: e.pageX - boardRef.current.offsetLeft,
+        y: e.pageY - boardRef.current.offsetTop,
       }
 
-      if (resizing) {
-        // If the card has no fixed dimensions yet, get its current rendered dimensions
-        if (!Number.isInteger(card.width) || !Number.isInteger(card.height)) {
-          this.handle &&
-            this.handle.change((b) => {
-              // clientWidth and clientHeight are rounded so we add 1px to get the ceiling,
-              // this prevents visual changes like scrollbar from triggering on drag
-              /* eslint react/no-find-dom-node: "off" */
-              b.cards[card.id].width = ReactDOM.findDOMNode(this.cardRefs[card.id]).clientWidth + 1
-              b.cards[card.id].height =
-                ReactDOM.findDOMNode(this.cardRefs[card.id]).clientHeight + 1
-            })
-
-          card = this.state.doc.cards[card.id]
-        }
-
-        const { type } = parseDocumentLink(card.url)
-        const { component = {} } = ContentTypes.lookup({ type, context: 'board' }) as any
-        const minWidth = gridCellsToPixels(component.minWidth) || CARD_MIN_WIDTH
-        const minHeight = gridCellsToPixels(component.minHeight) || CARD_MIN_HEIGHT
-        const maxWidth = gridCellsToPixels(component.maxWidth) || Infinity
-        const maxHeight = gridCellsToPixels(component.maxWidth) || Infinity
-
-        this.tracking[card.id] = {
-          dragType: DragType.RESIZING,
-          slackWidth: 0,
-          slackHeight: 0,
-          resizeWidth: card.width,
-          resizeHeight: card.height,
-          minWidth,
-          minHeight,
-          maxWidth,
-          maxHeight,
-        }
-      }
-
-      return
-    }
-
-    if (tracking.dragType === DragType.MOVING) {
-      const cards = draggableCards(this.state.doc.cards, this.state.selected, card)
-      cards.forEach((card) => {
-        const t = this.tracking[card.id]
-        this.effectDrag(card, t, d)
-
-        this.setState((prevState) => ({
-          tracking: {
-            ...prevState.tracking,
-            [card.id]: t,
-          },
-        }))
+      ContentTypes.create('text', { text: '' }, (url) => {
+        dispatch({ type: 'AddCardForContent', position, url })
       })
-    }
+    },
+    [boardRef, dispatch]
+  )
 
-    if (tracking.dragType === DragType.RESIZING) {
-      this.effectDrag(card, tracking, d)
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
 
-      this.setState((prevState) => ({
-        tracking: {
-          ...prevState.tracking,
-          [card.id]: tracking,
-        },
-      }))
-    }
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      // If we have an origin board, and it's us, this is a move operation.
+      const originBoard = e.dataTransfer.getData(BOARD_CARD_DRAG_ORIGIN)
+      if (originBoard === props.hypermergeUrl) {
+        onDropInternal(e)
+      } else {
+        onDropExternal(e)
+      }
+    },
+    [props.hypermergeUrl, selection, distance]
+  )
+
+  const onDropInternal = (e: React.DragEvent) => {
+    e.dataTransfer.dropEffect = 'move'
+    dispatch({ type: 'MoveCardsBy', selection, distance })
   }
 
-  onMessage = (msg) => {
-    const { contact, selected } = msg
-
-    if (contact && selected) {
-      this.setState((prevState) => ({
-        remoteSelection: {
-          ...prevState.remoteSelection,
-          [contact]: selected,
-        },
-      }))
-    }
-
-    // if we don't hear from another user for a while, assume they've gone offline
-    if (contact) {
-      clearTimeout(this.contactHeartbeatTimerId[contact])
-      // if we miss two heartbeats (11s), assume they've gone offline
-      this.contactHeartbeatTimerId[contact] = setTimeout(() => {
-        this.clearRemoteSelection(contact)
-      }, 3000)
-    }
-  }
-
-  clearRemoteSelection = (contact) => {
-    this.setState((prevState) => ({
-      remoteSelection: {
-        ...prevState.remoteSelection,
-        [contact]: undefined,
-      },
-    }))
-  }
-
-  updateSelection = (selected) => {
-    this.setState({ selected })
-    this.handle && this.handle.message({ contact: this.props.selfId, selected })
-  }
-
-  selectToggle = (cardId) => {
-    const { selected } = this.state
-
-    if (selected.includes(cardId)) {
-      // remove from the current state if we have it
-      this.updateSelection([selected.filter((filterId) => filterId !== cardId)])
-    } else {
-      // add to the current state if we don't
-      this.updateSelection([...selected, cardId])
-    }
-  }
-
-  selectOnly = (cardId) => {
-    this.updateSelection([cardId])
-  }
-
-  selectNone = () => {
-    this.updateSelection([])
-  }
-
-  onStop = (card, e, d) => {
-    log('onStop')
-    if (!(this.state.doc && this.state.doc.cards)) {
+  const onDropExternal = (e: React.DragEvent) => {
+    if (!boardRef.current) {
       return
     }
 
-    const { id } = card
-    const tracking = this.tracking[id]
-
-    // If tracking is not initialized, treat this as a click
-    if (!tracking) {
-      return
+    // Otherwise consttruct the drop point and import the data.
+    const { pageX, pageY } = e
+    const dropPosition = {
+      x: pageX - boardRef.current.offsetLeft,
+      y: pageY - boardRef.current.offsetTop,
     }
+    ImportData.importDataTransfer(e.dataTransfer, (url, i) => {
+      const position = gridOffset(dropPosition, i)
+      dispatch({ type: 'AddCardForContent', position, url })
+    })
+  }
 
-    if (tracking.dragType === DragType.MOVING) {
-      const cards = draggableCards(this.state.doc.cards, this.state.selected, card)
-      cards.forEach((card) => {
-        const t = this.tracking[card.id] as MoveTracking
+  const onPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      log('onPaste')
+      e.preventDefault()
+      e.stopPropagation()
 
-        const position = { x: t.moveX, y: t.moveY }
-        this.cardMoved({ id: card.id, position })
-      })
-      this.tracking = {}
-      this.setState({ tracking: {} })
-    }
-
-    if (tracking.dragType === DragType.RESIZING) {
-      const dimension = {
-        width: tracking.resizeWidth,
-        height: tracking.resizeHeight,
+      if (!e.clipboardData) {
+        return
       }
 
-      this.cardResized({ id: card.id, dimension })
-      this.tracking = {}
-      this.setState({ tracking: {} })
-    }
+      /* We can't get the mouse position on a paste event,
+         so we just stick the card in the middle of the current scrolled position screen.
+         (We bump it a bit to the left too to pretend we're really centering, but doing that
+         would require knowledge of the card's ) */
+      const position = {
+        x: window.pageXOffset + window.innerWidth / 2 - GRID_SIZE * 6,
+        y: window.pageYOffset + window.innerHeight / 2,
+      }
 
-    this.finishedDrag = true
-  }
+      ImportData.importDataTransfer(e.clipboardData, (url, i) => {
+        const offsetPosition = gridOffset(position, i)
+        dispatch({ type: 'AddCardForContent', position: offsetPosition, url })
+      })
+    },
+    [dispatch]
+  )
 
-  render = () => {
-    log('render')
-    if (!(this.state.doc && this.state.doc.cards)) {
-      return null
-    }
+  const docTitle = doc && doc.title ? doc.title : ''
+  const contentTypes = useMemo(() => ContentTypes.list({ context: 'board' }), [])
+  const { backgroundColor = '#fff' } = doc || {}
 
-    // invert the client->cards to a cards->client mapping
-    const { remoteSelection } = this.state
-    const cardsSelected = {}
-    Object.entries(remoteSelection).forEach(([contact, cards]) => {
-      cards &&
-        cards.forEach((card) => {
-          if (!cardsSelected[card]) {
-            cardsSelected[card] = []
-          }
-          cardsSelected[card].push(contact)
-        })
-    })
+  const style = useMemo(
+    () => ({
+      backgroundColor,
+      width: BOARD_WIDTH,
+      height: BOARD_HEIGHT,
+    }),
+    [backgroundColor]
+  )
 
-    const cards = this.state.doc.cards || {}
-    const cardChildren = Object.entries(cards).map(([id, card]) => {
-      const selected = this.state.selected.includes(id)
-      const uniquelySelected = selected && this.state.selected.length === 1
-      return (
-        <BoardCard
-          key={id}
-          id={id}
-          boardUrl={this.props.hypermergeUrl}
-          card={card}
-          selected={selected}
-          remoteSelected={cardsSelected[id] || []}
-          uniquelySelected={uniquelySelected}
-          dragState={this.state.tracking[id]}
-          onDrag={this.onDrag}
-          onStop={this.onStop}
-          onCardClicked={this.onCardClicked}
-          onCardDoubleClicked={this.onCardDoubleClicked}
-          setCardRef={this.setCardRef}
-        />
-      )
-    })
+  /**
+   * at long last, render begins here
+   */
+  log('render')
 
+  const { cards = [] } = doc || {}
+  const cardChildren = Object.entries(cards).map(([id, card]) => {
+    const isSelected = selection.includes(id as CardId) // sadly we can't have IDs as non-string types
+    const uniquelySelected = isSelected && selection.length === 1
     return (
-      <div
-        className="Board"
-        ref={this.boardRef}
-        style={{
-          backgroundColor: this.state.doc.backgroundColor,
-          width: BOARD_WIDTH,
-          height: BOARD_HEIGHT,
-        }}
-        onKeyDown={this.onKeyDown}
-        onClick={this.onClick}
-        onDoubleClick={this.onDoubleClick}
-        onDragOver={this.onDragOver}
-        onDrop={this.onDrop}
-        onPaste={this.onPaste}
-        role="presentation"
-      >
-        <BoardContextMenu
-          boardTitle={this.state.doc.title}
-          contentTypes={ContentTypes.list({ context: 'board' })}
-          addCardForContent={this.addCardForContent}
-          backgroundColor={this.state.doc.backgroundColor || BOARD_COLORS.DEFAULT}
-          backgroundColors={BOARD_COLOR_VALUES}
-          changeBackgroundColor={this.changeBackgroundColor}
-        />
-        <ContextMenuTrigger holdToDisplay={-1} id="BoardMenu">
-          <div>{cardChildren}</div>
-        </ContextMenuTrigger>
-      </div>
+      <BoardCard
+        key={id}
+        id={id as CardId}
+        x={card.x}
+        y={card.y}
+        width={card.width}
+        height={card.height}
+        url={card.url}
+        boardUrl={props.hypermergeUrl}
+        dragOffsetX={isSelected ? distance.x : 0}
+        dragOffsetY={isSelected ? distance.y : 0}
+        selected={isSelected}
+        uniquelySelected={uniquelySelected}
+        dispatch={dispatch}
+      />
     )
-  }
+  })
+
+  return (
+    <div
+      className="Board"
+      ref={boardRef}
+      style={style}
+      onKeyDown={onKeyDown}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      onDragOver={onDragOver}
+      onDragEnter={onDragOver}
+      onDrop={onDrop}
+      onPaste={onPaste}
+      role="presentation"
+    >
+      <BoardContextMenu
+        boardTitle={docTitle}
+        contentTypes={contentTypes}
+        dispatch={dispatch}
+        backgroundColor={backgroundColor}
+        backgroundColors={BOARD_COLOR_VALUES}
+      />
+      <ContextMenuTrigger holdToDisplay={-1} id="BoardMenu">
+        <div>{cardChildren}</div>
+      </ContextMenuTrigger>
+    </div>
+  )
 }
+
+export default memo(Board)

--- a/src/renderer/components/content-types/board/BoardBoundary.ts
+++ b/src/renderer/components/content-types/board/BoardBoundary.ts
@@ -1,0 +1,59 @@
+/* The board prevents cards from getting outside itself, which is a little tricky.
+ */
+
+import { BOARD_HEIGHT, BOARD_WIDTH } from './Board'
+import { Dimension, Position, gridCellsToPixels } from './BoardGrid'
+import { PushpinUrl, parseDocumentLink } from '../../../ShareLink'
+import ContentTypes from '../../../ContentTypes'
+
+export const boundPosition = (
+  { x, y }: Position,
+  { width = 0, height = 0 }: Dimension
+): Position => ({
+  x: Math.min(Math.max(x, 0), BOARD_WIDTH - width),
+  y: Math.min(Math.max(y, 0), BOARD_HEIGHT - height),
+})
+
+export const boundDimension = (
+  { x, y }: Position,
+  { width = 0, height = 0 }: Dimension
+): Dimension => ({
+  width: Math.min(width, BOARD_WIDTH - x),
+  height: Math.min(height, BOARD_HEIGHT - y),
+})
+
+const CARD_MIN_WIDTH = 4
+const CARD_MIN_HEIGHT = 2
+const CARD_MAX_WIDTH = 72
+const CARD_MAX_HEIGHT = 72
+
+export const boundSizeByType = (
+  url: PushpinUrl,
+  { width = 0, height = 0 }: Dimension
+): Dimension => {
+  const { type } = parseDocumentLink(url)
+  const { component = {} } = ContentTypes.lookup({ type, context: 'board' }) || {}
+  const {
+    minWidth = CARD_MIN_WIDTH,
+    minHeight = CARD_MIN_HEIGHT,
+    maxWidth = CARD_MAX_WIDTH,
+    maxHeight = CARD_MAX_HEIGHT,
+  } = component as any // when we care, we set this as properties on components
+
+  // this undefined values option for dimensions is super annoying
+  const bounds = {
+    min: {
+      width: gridCellsToPixels(minWidth) || 0,
+      height: gridCellsToPixels(minHeight) || 0,
+    },
+    max: {
+      width: gridCellsToPixels(maxWidth) || 0,
+      height: gridCellsToPixels(maxHeight) || 0,
+    },
+  }
+
+  return {
+    width: Math.min(bounds.max.width, Math.max(bounds.min.width, width)),
+    height: Math.min(bounds.max.height, Math.max(bounds.min.height, height)),
+  }
+}

--- a/src/renderer/components/content-types/board/BoardCard.css
+++ b/src/renderer/components/content-types/board/BoardCard.css
@@ -23,19 +23,6 @@
   z-index: 2;
 }
 
-.BoardCard--text {
-  /* use an inset box-shadow to avoid the mitering of corners with normal borders */
-  min-width: 48px;
-  max-width: 481px;
-}
-
-.BoardCard--image {
-  padding: 12px;
-  box-sizing: border-box;
-  background: white;
-  border: solid 1px var(--colorPaleGrey);
-}
-
 .BoardCard-resizeHandle {
   position: absolute;
   width: 16px;

--- a/src/renderer/components/content-types/board/BoardCard.tsx
+++ b/src/renderer/components/content-types/board/BoardCard.tsx
@@ -1,118 +1,244 @@
-import React from 'react'
-import { DraggableCore, DraggableData } from 'react-draggable'
+import React, { useState, useRef } from 'react'
 import classNames from 'classnames'
+import mime from 'mime-types'
 
 import Content from '../../Content'
 import ContentTypes from '../../../ContentTypes'
 import { parseDocumentLink, HypermergeUrl } from '../../../ShareLink'
 
-import { BoardDocCard } from '.'
-import { TrackingEntry, DragType, isResizing, isMoving } from './Board'
-import { ContactDoc } from '../contact'
-import { useDocument } from '../../../Hooks'
+import { BoardDocCard, CardId } from '.'
+import { Position, Dimension } from './BoardGrid'
+import { usePresence, useSelf, useDocument } from '../../../Hooks'
 import './BoardCard.css'
+import { PUSHPIN_DRAG_TYPE, BOARD_CARD_DRAG_ORIGIN } from '../../../constants'
+import { boundDimension, boundSizeByType } from './BoardBoundary'
 
-type DraggableEvent =
-  | React.MouseEvent<HTMLElement | SVGElement>
-  | React.TouchEvent<HTMLElement | SVGElement>
-  | MouseEvent
-  | TouchEvent
+interface CardClicked {
+  type: 'CardClicked'
+  cardId: CardId
+  event: React.MouseEvent
+}
+interface CardDoubleClicked {
+  type: 'CardDoubleClicked'
+  cardId: CardId
+  event: React.MouseEvent
+}
+interface CardResized {
+  type: 'CardResized'
+  cardId: CardId
+  dimension: Dimension
+}
 
-interface BoardCardProps {
-  id: string
+interface CardDragging {
+  type: 'CardDragging'
+  distance: Position
+}
+
+export type BoardCardAction = CardClicked | CardDoubleClicked | CardResized | CardDragging
+
+interface BoardCardProps extends BoardDocCard {
+  id: CardId
   boardUrl: HypermergeUrl
-  card: BoardDocCard
-
-  dragState: TrackingEntry
-
   selected: boolean
   uniquelySelected: boolean
-  remoteSelected: HypermergeUrl[]
 
-  onDrag(card: BoardDocCard, event: DraggableEvent, dragData: DraggableData): void
-  onStop(card: BoardDocCard, event: DraggableEvent, dragData: DraggableData): void
-  onCardClicked(card: BoardDocCard, event: React.MouseEvent): void
-  onCardDoubleClicked(card: BoardDocCard, event: React.MouseEvent): void
-  setCardRef(id: string, ref: HTMLElement | null): void
+  dispatch(action: BoardCardAction): void
+  dragOffsetX: number
+  dragOffsetY: number
+}
+
+interface Presence {
+  color: string | null
 }
 
 export default function BoardCard(props: BoardCardProps) {
+  const { dispatch, id, url, x, y, width, height } = props
+
+  const [self] = useSelf()
+  const remotePresences = usePresence<Presence>(
+    props.boardUrl,
+    props.selected && self
+      ? {
+          color: self.color,
+        }
+      : null,
+    id
+  )
+  const remotePresence = Object.values(remotePresences)[0]
+  const highlightColor = remotePresence && remotePresence.color
+
+  const [dragStart, setDragStart] = useState<Position | null>(null)
+
+  const [resizeStart, setResizeStart] = useState<Position | null>(null)
+
+  const selected = props.selected || remotePresence
+  const [resize, setResize] = useState<Dimension | null>(null)
+
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  const { hypermergeUrl } = parseDocumentLink(url)
+  const [doc] = useDocument<any>(hypermergeUrl)
+
   const {
-    card,
-    dragState = { dragState: DragType.NOT_DRAGGING },
-    remoteSelected: [remoteSelectorContact],
-  } = props
+    hyperfileUrl = null,
+    title = 'untitled',
+    mimeType = 'application/octet',
+    extension = null,
+  } = doc || {}
 
-  const [doc] = useDocument<ContactDoc>(remoteSelectorContact || null)
-  const highlightColor = doc && doc.color
-
-  function onDrag(e: DraggableEvent, d: DraggableData) {
-    props.onDrag(card, e, d)
+  function onCardClicked(event: React.MouseEvent) {
+    dispatch({ type: 'Clicked', cardId: id, event })
   }
 
-  function onStop(e: DraggableEvent, d: DraggableData) {
-    props.onStop(card, e, d)
-  }
-
-  function onCardClicked(e: React.MouseEvent) {
-    props.onCardClicked(card, e)
-  }
-
-  function onCardDoubleClicked(e: React.MouseEvent) {
-    props.onCardDoubleClicked(card, e)
-  }
-
-  function setCardRef(node: HTMLElement | null) {
-    props.setCardRef(props.id, node)
+  function onCardDoubleClicked(event: React.MouseEvent) {
+    dispatch({ type: 'DoubleClicked', cardId: id, event })
   }
 
   function stopPropagation(e: React.SyntheticEvent) {
     e.stopPropagation()
   }
 
-  const style: React.CSSProperties = {
-    ['--highlight-color' as any]: highlightColor,
-    position: 'absolute',
-    width: isResizing(dragState) ? dragState.resizeWidth : card.width,
-    height: isResizing(dragState) ? dragState.resizeHeight : card.height,
-    left: isMoving(dragState) ? dragState.moveX : card.x,
-    top: isMoving(dragState) ? dragState.moveY : card.y,
+  function onDragStart(event: React.DragEvent) {
+    if (!selected) {
+      dispatch({ type: 'Clicked', cardId: id, event })
+    }
+
+    setDragStart({ x: event.pageX, y: event.pageY })
+
+    // when dragging on the board, we want to maintain the true card element
+    event.dataTransfer.setDragImage(document.createElement('img'), 0, 0)
+
+    // annotate the drag with the current board's URL so we can tell if this is where we came from
+    event.dataTransfer.setData(BOARD_CARD_DRAG_ORIGIN, props.boardUrl)
+
+    // we'll add the PUSHPIN_DRAG_TYPE to support dropping into non-board places
+    event.dataTransfer.setData(PUSHPIN_DRAG_TYPE, url)
+
+    // and we'll add a DownloadURL
+    if (hyperfileUrl) {
+      const outputExtension = extension || mime.extension(mimeType) || ''
+
+      const downloadUrl = `text:${title}.${outputExtension}:${hyperfileUrl}`
+      event.dataTransfer.setData('DownloadURL', downloadUrl)
+    }
   }
 
-  const { type } = parseDocumentLink(card.url)
+  // we don't want to make changes to the document until the drag ends
+  // but we want to move the actual DOM element during the drag so that
+  // we don't have ugly ghosting
+  function onDrag(e: React.DragEvent) {
+    if (!dragStart) {
+      return
+    }
+
+    // if you drag outside the window, you'll get an onDrag where pageX and pageY are zero.
+    // this sticks the drag preview into a dumb spot, so we're just going to filter those out
+    // unless anyone has a better idea.
+    if (e.screenX === 0 && e.screenY === 0) {
+      return
+    }
+
+    dispatch({ type: 'Dragging', distance: { x: e.pageX - dragStart.x, y: e.pageY - dragStart.y } })
+    e.preventDefault()
+  }
+
+  function onDragEnd(e: React.DragEvent) {
+    setDragStart(null)
+    dispatch({ type: 'Dragging', distance: { x: 0, y: 0 } })
+  }
+
+  const resizePointerDown = (event: React.PointerEvent) => {
+    if (!selected) {
+      dispatch({ type: 'Clicked', cardId: id, event })
+    }
+
+    if (!cardRef.current) {
+      return
+    }
+
+    setResizeStart({ x: event.pageX, y: event.pageY })
+    const widthC = width || cardRef.current.clientWidth
+    const heightC = height || cardRef.current.clientHeight
+    setResize({ width: widthC, height: heightC })
+    ;(event.target as Element).setPointerCapture(event.pointerId)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  const resizePointerMove = (e: React.PointerEvent) => {
+    if (!resize || !resizeStart) {
+      return
+    }
+
+    if (!cardRef.current) {
+      return
+    }
+
+    const deNulledWidth = width || cardRef.current.clientWidth
+    const deNulledHeight = height || cardRef.current.clientHeight
+
+    const movedSize = {
+      width: deNulledWidth - resizeStart.x + e.pageX,
+      height: deNulledHeight - resizeStart.y + e.pageY,
+    }
+
+    const clampedSize = boundSizeByType(url, movedSize)
+    const boundedSize = boundDimension({ x, y }, clampedSize)
+
+    setResize(boundedSize)
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  const resizePointerUp = (e: React.PointerEvent) => {
+    ;(e.target as Element).releasePointerCapture(e.pointerId)
+    if (resize) {
+      dispatch({ type: 'Resized', cardId: id, dimension: resize })
+    }
+    setResizeStart(null)
+    setResize(null)
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  const style: React.CSSProperties = {
+    ['--highlight-color' as any]: highlightColor,
+    width: resize ? resize.width : width,
+    height: resize ? resize.height : height,
+    position: 'absolute',
+    left: x + props.dragOffsetX,
+    top: y + props.dragOffsetY,
+  }
+
+  const { type } = parseDocumentLink(url)
   const context = 'board'
   const contentType = ContentTypes.lookup({ type, context })
 
-  const selected = props.selected || props.remoteSelected.length > 0
-
   return (
-    <DraggableCore
-      key={props.id}
-      allowAnyClick={false}
-      disabled={false}
-      enableUserSelectHack={false}
+    <div
+      tabIndex={-1}
+      ref={cardRef}
+      id={`card-${id}`}
+      className={classNames('BoardCard', selected && 'BoardCard--selected')}
+      style={style}
+      onClick={onCardClicked}
+      onDoubleClick={onCardDoubleClicked}
+      onContextMenu={stopPropagation}
+      draggable
       onDrag={onDrag}
-      onStop={onStop}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
     >
-      <div
-        ref={setCardRef}
-        tabIndex={-1}
-        id={`card-${card.id}`}
-        className={classNames(
-          'BoardCard',
-          `BoardCard-${card.type}`,
-          selected && 'BoardCard--selected'
-        )}
-        style={style}
-        onClick={onCardClicked}
-        onDoubleClick={onCardDoubleClicked}
-        onContextMenu={stopPropagation}
-      >
-        <Content context="board" url={card.url} uniquelySelected={props.uniquelySelected} />
-        {contentType && contentType.resizable !== false && (
-          <span className="BoardCard-resizeHandle" />
-        )}
-      </div>
-    </DraggableCore>
+      <Content context="board" url={url} uniquelySelected={props.uniquelySelected} />
+      {contentType && contentType.resizable !== false && (
+        <span
+          onPointerDown={resizePointerDown}
+          onPointerMove={resizePointerMove}
+          onPointerUp={resizePointerUp}
+          onPointerCancel={resizePointerUp}
+          className="BoardCard-resizeHandle"
+        />
+      )}
+    </div>
   )
 }

--- a/src/renderer/components/content-types/board/BoardCard.tsx
+++ b/src/renderer/components/content-types/board/BoardCard.tsx
@@ -87,11 +87,11 @@ export default function BoardCard(props: BoardCardProps) {
   } = doc || {}
 
   function onCardClicked(event: React.MouseEvent) {
-    dispatch({ type: 'Clicked', cardId: id, event })
+    dispatch({ type: 'CardClicked', cardId: id, event })
   }
 
   function onCardDoubleClicked(event: React.MouseEvent) {
-    dispatch({ type: 'DoubleClicked', cardId: id, event })
+    dispatch({ type: 'CardDoubleClicked', cardId: id, event })
   }
 
   function stopPropagation(e: React.SyntheticEvent) {
@@ -100,7 +100,7 @@ export default function BoardCard(props: BoardCardProps) {
 
   function onDragStart(event: React.DragEvent) {
     if (!selected) {
-      dispatch({ type: 'Clicked', cardId: id, event })
+      dispatch({ type: 'CardClicked', cardId: id, event })
     }
 
     setDragStart({ x: event.pageX, y: event.pageY })
@@ -138,18 +138,21 @@ export default function BoardCard(props: BoardCardProps) {
       return
     }
 
-    dispatch({ type: 'Dragging', distance: { x: e.pageX - dragStart.x, y: e.pageY - dragStart.y } })
+    dispatch({
+      type: 'CardDragging',
+      distance: { x: e.pageX - dragStart.x, y: e.pageY - dragStart.y },
+    })
     e.preventDefault()
   }
 
   function onDragEnd(e: React.DragEvent) {
     setDragStart(null)
-    dispatch({ type: 'Dragging', distance: { x: 0, y: 0 } })
+    dispatch({ type: 'CardDragging', distance: { x: 0, y: 0 } })
   }
 
   const resizePointerDown = (event: React.PointerEvent) => {
     if (!selected) {
-      dispatch({ type: 'Clicked', cardId: id, event })
+      dispatch({ type: 'CardClicked', cardId: id, event })
     }
 
     if (!cardRef.current) {
@@ -193,7 +196,7 @@ export default function BoardCard(props: BoardCardProps) {
   const resizePointerUp = (e: React.PointerEvent) => {
     ;(e.target as Element).releasePointerCapture(e.pointerId)
     if (resize) {
-      dispatch({ type: 'Resized', cardId: id, dimension: resize })
+      dispatch({ type: 'CardResized', cardId: id, dimension: resize })
     }
     setResizeStart(null)
     setResize(null)

--- a/src/renderer/components/content-types/board/BoardContextMenu.tsx
+++ b/src/renderer/components/content-types/board/BoardContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, memo } from 'react'
 import classNames from 'classnames'
 import { ContextMenu, MenuItem as ContextMenuItem } from 'react-contextmenu'
 
@@ -6,7 +6,7 @@ import ColorPicker from '../../ColorPicker'
 import './ContextMenu.css'
 import ContentTypes, { LookupResult } from '../../../ContentTypes'
 import { importFileList } from '../../../ImportData'
-import { AddCardArgs } from './Board'
+import { BoardAction } from './Board'
 import { gridOffset, Position } from './BoardGrid'
 
 interface Props {
@@ -14,11 +14,10 @@ interface Props {
   boardTitle: string
   backgroundColor: string
   backgroundColors: string[]
-  addCardForContent(addArgs: AddCardArgs): void
-  changeBackgroundColor(color: string): void
+  dispatch(action: BoardAction): void
 }
 
-export default function BoardContextMenu(props: Props) {
+function BoardContextMenu(props: Props) {
   const [contextMenuPosition, setContextMenuPosition] = useState<Position>({ x: 0, y: 0 })
 
   const addContent = (e, contentType) => {
@@ -38,13 +37,13 @@ export default function BoardContextMenu(props: Props) {
             title: `Sub-board of ${props.boardTitle}`,
           },
           (url) => {
-            props.addCardForContent({ position, url })
+            props.dispatch({ type: 'AddCardForContent', position, url })
           }
         )
         break
       default:
         ContentTypes.create(contentType.type, {}, (url) => {
-          props.addCardForContent({ position, url })
+          props.dispatch({ type: 'AddCardForContent', position, url })
         })
     }
   }
@@ -66,7 +65,11 @@ export default function BoardContextMenu(props: Props) {
   }
   const onFilesChanged = (e) => {
     importFileList(e.target.files, (url, i) =>
-      props.addCardForContent({ position: gridOffset(contextMenuPosition, i), url })
+      props.dispatch({
+        type: 'AddCardForContent',
+        position: gridOffset(contextMenuPosition, i),
+        url,
+      })
     )
   }
 
@@ -76,6 +79,8 @@ export default function BoardContextMenu(props: Props) {
       y: e.detail.position.y - e.detail.target.parentElement.offsetLeft,
     })
   }
+
+  const onChangeComplete = (color) => props.dispatch({ type: 'ChangeBackgroundColor', color })
 
   return (
     <ContextMenu id="BoardMenu" onShow={onShowContextMenu} className="ContextMenu">
@@ -106,10 +111,12 @@ export default function BoardContextMenu(props: Props) {
           <ColorPicker
             color={props.backgroundColor}
             colors={props.backgroundColors}
-            onChangeComplete={props.changeBackgroundColor}
+            onChangeComplete={onChangeComplete}
           />
         </ContextMenuItem>
       </div>
     </ContextMenu>
   )
 }
+
+export default memo(BoardContextMenu)

--- a/src/renderer/components/content-types/board/BoardDocManipulation.ts
+++ b/src/renderer/components/content-types/board/BoardDocManipulation.ts
@@ -1,0 +1,135 @@
+import { BoardDoc, CardId, BoardDocCard } from '.'
+import { AddCardArgs } from './Board'
+import { parseDocumentLink } from '../../../ShareLink'
+import ContentTypes from '../../../ContentTypes'
+import {
+  gridCellsToPixels,
+  snapPositionToGrid,
+  snapDimensionToGrid,
+  Dimension,
+  Position,
+} from './BoardGrid'
+import { boundPosition } from './BoardBoundary'
+import { Selection } from './BoardSelection'
+
+import uuid = require('uuid')
+
+/*
+ * Card manipulation functions
+ * all the functions in this section call changeDoc
+ */
+export const addCardForContent = (b: BoardDoc, { position, dimension, url }: AddCardArgs) => {
+  const id = uuid() as CardId // ehhhhh
+
+  const { type } = parseDocumentLink(url)
+  const { component = {} } = ContentTypes.lookup({ type, context: 'board' }) as any
+
+  if (!dimension)
+    dimension = {
+      width: gridCellsToPixels(component.defaultWidth),
+      height: gridCellsToPixels(component.defaultHeight),
+    }
+
+  const { x, y } = snapPositionToGrid(position)
+  const { width, height } = snapDimensionToGrid(dimension)
+  const newCard: BoardDocCard = {
+    url,
+    x,
+    y,
+  }
+  // Automerge doesn't accept undefined values,
+  // which we use to indicate content should set its own size on that dimension.
+  if (width) {
+    newCard.width = width
+  }
+  if (height) {
+    newCard.height = height
+  }
+
+  // XXX: this should be keeping the card within the board bounds
+
+  b.cards[id] = newCard
+
+  return id
+}
+
+export const moveCardsBy = (b: BoardDoc, selected: CardId[], offset: Position) => {
+  selected.forEach((id) => {
+    const position = {
+      x: b.cards[id].x + offset.x,
+      y: b.cards[id].y + offset.y,
+    }
+
+    // XXX: this line here is why cards can escape the bounds of the app
+    //      we need to do some design around how to handle "floating" dimensions
+    //      like width & height so we don't encounter this anymore
+    const size = {
+      width: b.cards[id].width || 0,
+      height: b.cards[id].height || 0,
+    }
+
+    const boundedPosition = boundPosition(position, size)
+    const newPosition = snapPositionToGrid(boundedPosition)
+
+    // This gets called when uniquely selecting a card, so avoid a document
+    // change if in fact the card hasn't moved mod snapping.
+    const cardPosition = { x: b.cards[id].x, y: b.cards[id].y }
+    if (newPosition.x === cardPosition.x && newPosition.y === cardPosition.y) {
+      return
+    }
+
+    const card = b.cards[id]
+    card.x = newPosition.x
+    card.y = newPosition.y
+  })
+}
+
+export const cardResized = (b: BoardDoc, id: CardId, dimension: Dimension) => {
+  // This gets called when uniquely selecting a card, so avoid a document
+  // change if in fact the card hasn't moved mod snapping.
+  const snapDimension = snapDimensionToGrid(dimension)
+  const cardDimension = { width: b.cards[id].width, height: b.cards[id].height }
+  if (
+    snapDimension.width === cardDimension.width &&
+    snapDimension.height === cardDimension.height
+  ) {
+    return
+  }
+
+  const card = b.cards[id]
+  card.width = snapDimension.width
+  card.height = snapDimension.height
+}
+
+export const deleteCards = (b: BoardDoc, ids: CardId[]) => {
+  ids.forEach((id) => delete b.cards[id])
+}
+
+export const changeBackgroundColor = (b: BoardDoc, color: any) => {
+  b.backgroundColor = color.hex
+}
+
+interface DeleteCards {
+  type: 'DeleteCards'
+  selection: Selection<CardId>
+}
+interface MoveCardsBy {
+  type: 'MoveCardsBy'
+  selection: Selection<CardId>
+  distance: Position
+}
+interface AddCardForContent extends AddCardArgs {
+  type: 'AddCardForContent'
+  selectOnly?: boolean
+}
+
+interface ChangeBackgroundColor {
+  type: 'ChangeBackgroundColor'
+  color: any // this is a weird type from some react component
+}
+
+export type BoardDocManipulationAction =
+  | DeleteCards
+  | MoveCardsBy
+  | AddCardForContent
+  | ChangeBackgroundColor

--- a/src/renderer/components/content-types/board/BoardSelection.ts
+++ b/src/renderer/components/content-types/board/BoardSelection.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { useStaticCallback } from '../../../Hooks'
+
+export type Selection<T> = T[]
+
+/*
+ * Selection manipulation functions
+ * these functional control the currently selected set of cards
+ */
+export function useSelection<T>(): {
+  selection: Selection<T>
+  selectToggle: (id: T) => void
+  selectOnly: (id: T) => void
+  selectNone: () => void
+} {
+  const [selection, setSelection] = useState<T[]>([])
+
+  const selectToggle = useStaticCallback((id: T) =>
+    setSelection((selected) =>
+      selected.includes(id) ? selected.filter((filterId) => filterId !== id) : [...selected, id]
+    )
+  )
+
+  const selectOnly = useStaticCallback((id: T) => {
+    setSelection([id])
+  })
+
+  const selectNone = useStaticCallback(() => {
+    setSelection([])
+  })
+
+  return { selection, selectOnly, selectToggle, selectNone }
+}

--- a/src/renderer/components/content-types/board/index.ts
+++ b/src/renderer/components/content-types/board/index.ts
@@ -7,14 +7,14 @@ import BoardInBoard from './BoardInBoard'
 import BoardInList from './BoardInList'
 import { HypermergeUrl, PushpinUrl } from '../../../ShareLink'
 
+export type CardId = string & { cardId: true }
+
 export interface BoardDocCard {
-  type: string
-  id: string
   url: PushpinUrl
   x: number
   y: number
-  height: number
-  width: number
+  height?: number
+  width?: number
 }
 
 export interface BoardDoc {

--- a/src/renderer/components/content-types/contact/ContactInVarious.tsx
+++ b/src/renderer/components/content-types/contact/ContactInVarious.tsx
@@ -12,7 +12,7 @@ import Text from '../../Text'
 import Label from '../../Label'
 
 import './ContactInVarious.css'
-import { useDocument, useHyperfile, useMessaging, useTimeoutWhen } from '../../../Hooks'
+import { useDocument, useMessaging, useTimeoutWhen } from '../../../Hooks'
 
 const log = Debug('pushpin:settings')
 
@@ -24,7 +24,9 @@ export default function ContactInVarious(props: ContentProps) {
   const name = contact ? contact.name : null
 
   const [avatarImageDoc] = useDocument<FileDoc>(avatarDocId)
-  const avatarImageData = useHyperfile(avatarImageDoc && avatarImageDoc.hyperfileUrl)
+  const { hyperfileUrl = null, mimeType = 'application/octet', extension = null } =
+    avatarImageDoc || {}
+
   const isOnline = isPresent || props.selfId === props.hypermergeUrl
 
   function onDragStart(e: React.DragEvent) {
@@ -32,15 +34,14 @@ export default function ContactInVarious(props: ContentProps) {
       'application/pushpin-url',
       createDocumentLink('contact', props.hypermergeUrl)
     )
-    if (!avatarImageData) {
-      return
-    }
-    const { data, mimeType } = avatarImageData
-    const blob = new Blob([data.buffer], { type: mimeType })
-    const url = URL.createObjectURL(blob)
-    const extension = mime.extension(mimeType) || ''
 
-    e.dataTransfer.setData('DownloadURL', `text:${name}.${extension}:${url}`)
+    // and we'll add a DownloadURL
+    if (hyperfileUrl) {
+      const outputExtension = extension || mime.extension(mimeType) || 'bin'
+
+      const downloadUrl = `text:${name}.${outputExtension}:${hyperfileUrl}`
+      e.dataTransfer.setData('DownloadURL', downloadUrl)
+    }
   }
 
   if (!contact) {

--- a/src/renderer/components/content-types/files/FileContent.tsx
+++ b/src/renderer/components/content-types/files/FileContent.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import mime from 'mime-types'
 import Content, { ContentProps } from '../../Content'
 import ContentTypes from '../../../ContentTypes'
 import { useDocument, useHyperfile } from '../../../Hooks'
@@ -27,24 +26,10 @@ export default function FileContent({ hypermergeUrl, context }: ContentProps) {
   const size =
     fileData && fileData.data && fileData.data.buffer ? fileData.data.buffer.byteLength : null
 
-  function onDragStart(e: React.DragEvent) {
-    e.dataTransfer.setData('application/pushpin-url', createDocumentLink('file', hypermergeUrl))
-    if (!fileData) {
-      return
-    }
-    const { data, mimeType } = fileData
-    const blob = new Blob([data.buffer], { type: mimeType })
-    const url = URL.createObjectURL(blob)
-    const extension = mime.extension(mimeType) || ''
-
-    e.dataTransfer.setData('DownloadURL', `text:${title}.${extension}:${url}`)
-  }
-
   function renderUnidentifiedFile() {
-    // i removed the draggable from the onDragStart for now
     return (
       <div className="FileContent">
-        <div className="Icon" onDragStart={onDragStart}>
+        <div className="Icon">
           <i className="fa fa-file " />
         </div>
         <div className="Caption">

--- a/src/renderer/components/content-types/files/index.ts
+++ b/src/renderer/components/content-types/files/index.ts
@@ -1,6 +1,7 @@
 import Debug from 'debug'
 import { Handle, HyperfileUrl } from 'hypermerge'
 import mime from 'mime-types'
+import path from 'path'
 import ContentTypes from '../../../ContentTypes'
 import FileContent from './FileContent'
 import FileInList from './FileInList'
@@ -12,6 +13,8 @@ const log = Debug('pushpin:filecontent')
 export interface FileDoc {
   title: string // names are editable and not an intrinsic part of the file
   hyperfileUrl: HyperfileUrl
+  extension: string
+  mimeType: string
 }
 
 function createFromFile(entry: File, handle: Handle<FileDoc>, callback) {
@@ -23,9 +26,13 @@ function createFromFile(entry: File, handle: Handle<FileDoc>, callback) {
     const mimeType = mime.contentType(entry.type) || 'application/octet-stream'
     Hyperfile.writeBuffer(buffer, mimeType)
       .then((hyperfileUrl) => {
-        handle.change((doc) => {
+        handle.change((doc: FileDoc) => {
+          const parsed = path.parse(name)
           doc.hyperfileUrl = hyperfileUrl
-          doc.title = name
+          doc.title = parsed.name
+          doc.extension = parsed.ext.slice(1)
+          doc.mimeType = mimeType
+          // save the mimetype so we don't have to look it up
         })
         callback()
       })

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -12,7 +12,7 @@ import { ContactDoc } from '../contact'
 
 import './Workspace.css'
 import { useDocument, useAllHeartbeats, useHeartbeat } from '../../../Hooks'
-import { BoardDoc } from '../board'
+import { BoardDoc, CardId } from '../board'
 
 const log = Debug('pushpin:workspace')
 
@@ -146,11 +146,9 @@ function create(attrs, handle, callback) {
       { title: 'Welcome to PushPin!', selfId: selfHypermergeUrl },
       (boardUrl) => {
         ContentTypes.create('text', { text: WELCOME_TEXT }, (textDocUrl) => {
-          const id = uuid()
+          const id = uuid() as CardId
           window.repo.change(parseDocumentLink(boardUrl).hypermergeUrl, (doc: BoardDoc) => {
             doc.cards[id] = {
-              type: 'text',
-              id,
               url: textDocUrl,
               x: 20,
               y: 20,

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -20,3 +20,7 @@ export const USER_PATH = Path.join(DATA_PATH, 'pushpin-v10', USER)
 export const WORKSPACE_URL_PATH = Path.join(USER_PATH, 'workspace-id.json')
 export const HYPERMERGE_PATH = Path.join(USER_PATH, 'hypermerge')
 export const HYPERFILE_PATH = Path.join(USER_PATH, 'hyperfile')
+
+// this next one should maybe just be URL list
+export const PUSHPIN_DRAG_TYPE = 'application/pushpin-url'
+export const BOARD_CARD_DRAG_ORIGIN = 'application/x-pushpin-board-source'

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -70,7 +70,7 @@ function initWorkspace(repo: RepoFrontend) {
     workspaceUrl = existingWorkspaceUrl
   } else {
     ContentTypes.create('workspace', {}, (newWorkspaceUrl) => {
-      saveWorkspaceUrl(workspaceUrl)
+      saveWorkspaceUrl(newWorkspaceUrl)
       workspaceUrl = newWorkspaceUrl
     })
   }


### PR DESCRIPTION
In order to implement file drag-out we needed to move to a new drag & drop design. This implementation doesn't support multiple selection (yet) but does support dragging out files (jankily.)

This is a first-look implementation for feedback.

TODO
 - [ ] better delegation of download URL creation
 - [ ] handle file extensions better
 - [x] multiple selection
 - [x] re-add resize code
 - [x] minimum sizes (tricky when moving things against the edge of the board)
 - [x] when you drag outside the board the preview jumps into the top-left corner (0,0?)
 - [x] drag out only drags the card that initiated the drag (further investigation makes this seem reasonable?)
 - [x] dragging out and dropping leaves selection in a broken state
 - [ ] workspace creation is broken (?)
 - [ ] performance is bad