### PR TITLE
Fix IPC socket path when running two instances of app

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,12 +3,10 @@ import raf from 'random-access-file'
 // const DiscoverySwarm = require('discovery-swarm')
 // const defaults = require('dat-swarm-defaults')
 import DiscoverySwarm from 'discovery-cloud-client'
-
 import { RepoBackend } from 'hypermerge'
-import ipc from 'node-ipc'
-
 import { ToBackendRepoMsg } from 'hypermerge/dist/RepoMsg'
 import { Socket } from 'net'
+import ipc from '../ipc'
 import { HYPERMERGE_PATH, FILE_SERVER_PATH } from '../renderer/constants'
 
 window._debug = {}
@@ -22,10 +20,7 @@ back.startFileServer(FILE_SERVER_PATH)
 window._debug.repo = back
 window._debug.discovery = discovery
 
-ipc.config.silent = true
-ipc.config.appspace = 'pushpin.'
 ipc.config.id = 'background'
-ipc.config.maxConnections = 1
 
 ipc.serve(() => {
   ipc.server.on('repo.msg', (msg: ToBackendRepoMsg) => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,0 +1,9 @@
+import ipc from 'node-ipc'
+import { USER } from './renderer/constants'
+
+ipc.config.silent = true
+ipc.config.appspace = `pushpin.${USER}.`
+ipc.config.maxRetries = 2 as any
+ipc.config.maxConnections = 1
+
+export default ipc

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { EventEmitter } from 'events'
-import ipc from 'node-ipc'
 import Fs from 'fs'
 import { RepoFrontend } from 'hypermerge'
 import { ToFrontendRepoMsg } from 'hypermerge/dist/RepoMsg'
+import ipc from '../ipc'
 import { WORKSPACE_URL_PATH } from './constants'
 import Root from './components/Root'
 
@@ -27,10 +27,7 @@ localStorage.removeItem('debug')
 // emitter leaks.
 EventEmitter.defaultMaxListeners = 500
 
-ipc.config.silent = true
-ipc.config.appspace = 'pushpin.'
 ipc.config.id = 'renderer'
-ipc.config.maxRetries = 2 as any
 
 function initHypermerge(cb: (repo: RepoFrontend) => void) {
   const front = new RepoFrontend()


### PR DESCRIPTION
Adds the `USER` name to the ipc socket path.

Previously, concurrent instances of the app would bind to the same socket, which occasionally caused race conditions when refreshing both at the same-ish time.