### PR TITLE
first draft of bringing workspace URLs into the Omnibox

### DIFF
--- a/src/renderer/WorkspaceHooks.ts
+++ b/src/renderer/WorkspaceHooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, createContext } from 'react'
+import { useEffect, useState, createContext, useCallback } from 'react'
 import Fs from 'fs'
 import { WORKSPACE_URL_PATH } from './constants'
 import { PushpinUrl } from './ShareLink'
@@ -42,26 +42,32 @@ export function useWorkspaceUrls(): UseWorkspaceUrlsHook {
   }, [workspaceUrls])
 
   useEffect(() => {
-    if (workspaceUrls) {
+    if (workspaceUrls.length > 0) {
       saveWorkspaceUrls(workspaceUrls)
     }
   }, [workspaceUrls])
 
-  function addWorkspaceUrl(newWorkspaceUrl) {
-    if (!workspaceUrls.includes(newWorkspaceUrl)) {
-      setWorkspaceUrls([newWorkspaceUrl, ...workspaceUrls])
-    }
-  }
+  const addWorkspaceUrl = useCallback(
+    (workspaceUrl) => {
+      if (!workspaceUrls.includes(workspaceUrl)) {
+        setWorkspaceUrls([workspaceUrl, ...workspaceUrls])
+      }
+    },
+    [workspaceUrls]
+  )
 
-  function removeWorkspaceUrl(workspaceUrl) {
-    setWorkspaceUrls(workspaceUrls.filter((w) => w === workspaceUrl))
-  }
+  const removeWorkspaceUrl = useCallback(
+    (workspaceUrl) => {
+      setWorkspaceUrls(workspaceUrls.filter((w) => w === workspaceUrl))
+    },
+    [workspaceUrls]
+  )
 
-  function createWorkspace() {
+  const createWorkspace = useCallback(() => {
     ContentTypes.create('workspace', {}, (newWorkspaceUrl: PushpinUrl) => {
       addWorkspaceUrl(newWorkspaceUrl)
     })
-  }
+  }, [workspaceUrls])
 
   return { workspaceUrls, addWorkspaceUrl, removeWorkspaceUrl, createWorkspace }
 }

--- a/src/renderer/WorkspaceHooks.ts
+++ b/src/renderer/WorkspaceHooks.ts
@@ -22,14 +22,14 @@ function saveWorkspaceUrls(workspaceUrls: PushpinUrl[]): void {
   Fs.writeFileSync(WORKSPACE_URL_PATH, JSON.stringify(workspaceUrlData))
 }
 
-export interface UseWorkspaceUrlsHook {
+export interface WorkspaceUrlsApi {
   workspaceUrls: PushpinUrl[]
   addWorkspaceUrl: (url: PushpinUrl) => void
   removeWorkspaceUrl: (url: PushpinUrl) => void
   createWorkspace: () => void
 }
 
-export function useWorkspaceUrls(): UseWorkspaceUrlsHook {
+export function useWorkspaceUrls(): WorkspaceUrlsApi {
   const [workspaceUrls, setWorkspaceUrls] = useState<PushpinUrl[]>([])
 
   useEffect(() => {
@@ -71,4 +71,4 @@ export function useWorkspaceUrls(): UseWorkspaceUrlsHook {
   return { workspaceUrls, addWorkspaceUrl, removeWorkspaceUrl, createWorkspace }
 }
 
-export const WorkspaceUrlsContext = createContext<UseWorkspaceUrlsHook | null>(null)
+export const WorkspaceUrlsContext = createContext<WorkspaceUrlsApi | null>(null)

--- a/src/renderer/WorkspaceHooks.ts
+++ b/src/renderer/WorkspaceHooks.ts
@@ -39,7 +39,7 @@ export function useWorkspaceUrls(): UseWorkspaceUrlsHook {
     } else {
       createWorkspace()
     }
-  }, [workspaceUrls])
+  }, [])
 
   useEffect(() => {
     if (workspaceUrls.length > 0) {
@@ -49,9 +49,8 @@ export function useWorkspaceUrls(): UseWorkspaceUrlsHook {
 
   const addWorkspaceUrl = useCallback(
     (workspaceUrl) => {
-      if (!workspaceUrls.includes(workspaceUrl)) {
-        setWorkspaceUrls([workspaceUrl, ...workspaceUrls])
-      }
+      const newWorkspaceUrls = [workspaceUrl, ...workspaceUrls.filter((u) => u !== workspaceUrl)]
+      setWorkspaceUrls(newWorkspaceUrls)
     },
     [workspaceUrls]
   )

--- a/src/renderer/components/Root.tsx
+++ b/src/renderer/components/Root.tsx
@@ -27,10 +27,6 @@ import './content-types/files/AudioContent'
 import './content-types/files/VideoContent'
 import './content-types/files/PdfContent'
 import System, { SystemContext } from '../System'
-<<<<<<< HEAD
-import { useWorkspaceUrl } from '../WorkspaceHooks'
-=======
->>>>>>> first draft of bringing workspace URLs into the Omnibox
 
 interface Props {
   repo: RepoFrontend
@@ -42,7 +38,7 @@ export default function Root({ repo, system }: Props) {
 
   const currentDeviceUrl = useCurrentDeviceUrl()
 
-  const { workspaceUrls, setWorkspaceUrl } = workspaceUrlsContextData
+  const { workspaceUrls, addWorkspaceUrl } = workspaceUrlsContextData
   if (!workspaceUrls[0]) {
     return null
   }
@@ -52,7 +48,7 @@ export default function Root({ repo, system }: Props) {
       <SystemContext.Provider value={system}>
         <WorkspaceUrlsContext.Provider value={workspaceUrlsContextData}>
           <CurrentDeviceContext.Provider value={currentDeviceUrl}>
-            <Content context="root" url={workspaceUrls[0]} setWorkspaceUrl={setWorkspaceUrl}/>
+            <Content context="root" url={workspaceUrls[0]} setWorkspaceUrl={addWorkspaceUrl} />
           </CurrentDeviceContext.Provider>
         </WorkspaceUrlsContext.Provider>
       </SystemContext.Provider>

--- a/src/renderer/components/Root.tsx
+++ b/src/renderer/components/Root.tsx
@@ -4,6 +4,7 @@ import { RepoFrontend } from 'hypermerge'
 import Content from './Content'
 import { RepoContext } from '../Hooks'
 import { useCurrentDeviceUrl, CurrentDeviceContext } from './content-types/workspace/Device'
+import { useWorkspaceUrls, WorkspaceUrlsContext } from '../WorkspaceHooks'
 
 // We load these modules here so that the content registry will have them.
 import './content-types/workspace/Workspace'
@@ -26,7 +27,10 @@ import './content-types/files/AudioContent'
 import './content-types/files/VideoContent'
 import './content-types/files/PdfContent'
 import System, { SystemContext } from '../System'
+<<<<<<< HEAD
 import { useWorkspaceUrl } from '../WorkspaceHooks'
+=======
+>>>>>>> first draft of bringing workspace URLs into the Omnibox
 
 interface Props {
   repo: RepoFrontend
@@ -34,19 +38,23 @@ interface Props {
 }
 
 export default function Root({ repo, system }: Props) {
-  const [workspaceUrl, setWorkspaceUrl] = useWorkspaceUrl()
+  const workspaceUrlsContextData = useWorkspaceUrls()
+
   const currentDeviceUrl = useCurrentDeviceUrl()
 
-  if (!workspaceUrl) {
+  const { workspaceUrls, setWorkspaceUrl } = workspaceUrlsContextData
+  if (!workspaceUrls[0]) {
     return null
   }
 
   return (
     <RepoContext.Provider value={repo}>
       <SystemContext.Provider value={system}>
-        <CurrentDeviceContext.Provider value={currentDeviceUrl}>
-          <Content context="root" url={workspaceUrl} setWorkspaceUrl={setWorkspaceUrl} />
-        </CurrentDeviceContext.Provider>
+        <WorkspaceUrlsContext.Provider value={workspaceUrlsContextData}>
+          <CurrentDeviceContext.Provider value={currentDeviceUrl}>
+            <Content context="root" url={workspaceUrls[0]} setWorkspaceUrl={setWorkspaceUrl}/>
+          </CurrentDeviceContext.Provider>
+        </WorkspaceUrlsContext.Provider>
       </SystemContext.Provider>
     </RepoContext.Provider>
   )

--- a/src/renderer/components/content-types/defaults/DefaultInList.tsx
+++ b/src/renderer/components/content-types/defaults/DefaultInList.tsx
@@ -27,21 +27,13 @@ export default function ListItem(props: ContentProps) {
 
   // TODO: pick background color based on url
   return (
-    <div className="DocLink" style={css.listItem}>
+    <div className="DocLink">
       <span draggable onDragStart={onDragStart}>
         <Badge icon={icon} />
       </span>
       <div className="DocLink__title">{doc.title || name}</div>
     </div>
   )
-}
-
-const css = {
-  listItem: {
-    padding: '5px',
-    border: '1px solid #eaeaea',
-    borderRadius: '4px',
-  },
 }
 
 ContentTypes.registerDefault({

--- a/src/renderer/components/content-types/workspace/Omnibox.css
+++ b/src/renderer/components/content-types/workspace/Omnibox.css
@@ -3,11 +3,11 @@
   overflow: hidden;
   background-color: #ffffff;
   box-shadow: 0 12px 32px 0 rgba(0, 0, 0, 0.2);
-  width: 478px;
+  width: 60%;
   z-index: 10;
   position: fixed;
   top: 52px;
-  left: 12px;
+  left: 20%;
   display: flex;
   flex-direction: column;
 }
@@ -36,6 +36,12 @@
 
 .Omnibox--header > input {
   flex: 1;
+}
+
+.Omnibox .ListMenu {
+  color: var(--colorBlueBlack);
+  height: 60vh;
+  overflow-y: scroll;
 }
 
 .Omnibox .ListMenu__item .Actions {

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -14,6 +14,8 @@ import {
   PushpinUrl,
 } from '../../../ShareLink'
 
+import { WorkspaceUrlsContext } from '../../../WorkspaceHooks'
+
 import InvitationsView from '../../../InvitationsView'
 import { ContactDoc } from '../contact'
 import Badge from '../../Badge'
@@ -32,6 +34,7 @@ export interface Props {
   active: boolean
   hypermergeUrl: HypermergeUrl
   omniboxFinished: Function
+  workspaceUrlsContext: UseWorkspaceUrlsHook
 }
 
 interface WorkspaceDoc {
@@ -579,6 +582,12 @@ export default class Omnibox extends React.PureComponent<Props, State> {
     if (!this.state.doc || !this.state.doc.currentDocUrl) {
       return null
     }
+
+    const WSAPI = this.props.workspaceUrlsContext
+    if (!WSAPI) {
+      return null
+    }
+    const { workspaceUrls } = WSAPI
 
     return (
       <div className="Omnibox">

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -14,7 +14,7 @@ import {
   PushpinUrl,
 } from '../../../ShareLink'
 
-import { UseWorkspaceUrlsHook } from '../../../WorkspaceHooks'
+import { WorkspaceUrlsApi } from '../../../WorkspaceHooks'
 
 import InvitationsView from '../../../InvitationsView'
 import { ContactDoc } from '../contact'
@@ -34,7 +34,7 @@ export interface Props {
   active: boolean
   hypermergeUrl: HypermergeUrl
   omniboxFinished: Function
-  workspaceUrlsContext: UseWorkspaceUrlsHook | null
+  workspaceUrlsContext: WorkspaceUrlsApi | null
 }
 
 interface WorkspaceDoc {

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -435,6 +435,15 @@ export default class Omnibox extends React.PureComponent<Props, State> {
           .filter(([id, doc]) => doc.name.match(new RegExp(state.search, 'i')))
           .map(([id, doc]) => ({ url: createDocumentLink('contact', id as HypermergeUrl) })),
     },
+    {
+      name: 'workspaces',
+      label: 'Workspaces',
+      actions: [this.view],
+      items: (state, props) =>
+        !this.props.workspaceUrlsContext
+          ? []
+          : this.props.workspaceUrlsContext.workspaceUrls.map((url) => ({ url })),
+    },
   ]
   /* end sections */
 
@@ -576,6 +585,36 @@ export default class Omnibox extends React.PureComponent<Props, State> {
     clipboard.writeText(createDocumentLink('workspace', this.props.hypermergeUrl))
   }
 
+  renderOmniboxHeader = () => {
+    return (
+      <div className="Omnibox--header">
+        <input
+          className="Omnibox--input"
+          type="text"
+          ref={this.omniboxInput}
+          onChange={this.onInputChange}
+          value={this.state.search}
+          placeholder="Search..."
+        />
+        <div className="Omnibox--Workspace" onClick={this.onClickWorkspace}>
+          <Content
+            context="title-bar"
+            url={createDocumentLink('workspace', this.props.hypermergeUrl)}
+          />
+        </div>
+        <div className="Omnibox--Workspace">
+          <button
+            className="BoardTitle__clipboard BoardTitle__labeledIcon TitleBar__menuItem"
+            type="button"
+            onClick={this.onClickWorkspaceCopy}
+          >
+            <i className="fa fa-clipboard" />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   render = () => {
     log('render')
 
@@ -583,39 +622,9 @@ export default class Omnibox extends React.PureComponent<Props, State> {
       return null
     }
 
-    const WSAPI = this.props.workspaceUrlsContext
-    if (!WSAPI) {
-      return null
-    }
-    const { workspaceUrls } = WSAPI
-
     return (
       <div className="Omnibox">
-        <div className="Omnibox--header">
-          <input
-            className="Omnibox--input"
-            type="text"
-            ref={this.omniboxInput}
-            onChange={this.onInputChange}
-            value={this.state.search}
-            placeholder="Search..."
-          />
-          <div className="Omnibox--Workspace" onClick={this.onClickWorkspace}>
-            <Content
-              context="title-bar"
-              url={createDocumentLink('workspace', this.props.hypermergeUrl)}
-            />
-          </div>
-          <div className="Omnibox--Workspace">
-            <button
-              className="BoardTitle__clipboard BoardTitle__labeledIcon TitleBar__menuItem"
-              type="button"
-              onClick={this.onClickWorkspaceCopy}
-            >
-              <i className="fa fa-clipboard" />
-            </button>
-          </div>
-        </div>
+        {this.renderOmniboxHeader()}
         <ListMenu>
           {this.renderInvitationsSection()}
           {this.sectionDefinitions.map((sectionDefinition) =>

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -14,7 +14,7 @@ import {
   PushpinUrl,
 } from '../../../ShareLink'
 
-import { WorkspaceUrlsContext } from '../../../WorkspaceHooks'
+import { UseWorkspaceUrlsHook } from '../../../WorkspaceHooks'
 
 import InvitationsView from '../../../InvitationsView'
 import { ContactDoc } from '../contact'

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -440,7 +440,7 @@ export default class Omnibox extends React.PureComponent<Props, State> {
       label: 'Workspaces',
       actions: [this.view],
       items: (state, props) =>
-        !this.props.workspaceUrlsContext
+        !this.props.workspaceUrlsContext || state.search
           ? []
           : this.props.workspaceUrlsContext.workspaceUrls.map((url) => ({ url })),
     },

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -34,7 +34,7 @@ export interface Props {
   active: boolean
   hypermergeUrl: HypermergeUrl
   omniboxFinished: Function
-  workspaceUrlsContext: UseWorkspaceUrlsHook
+  workspaceUrlsContext: UseWorkspaceUrlsHook | null
 }
 
 interface WorkspaceDoc {

--- a/src/renderer/components/content-types/workspace/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/Omnibox.tsx
@@ -440,6 +440,7 @@ export default class Omnibox extends React.PureComponent<Props, State> {
       label: 'Workspaces',
       actions: [this.view],
       items: (state, props) =>
+        // we hide workspace results during a search right now
         !this.props.workspaceUrlsContext || state.search
           ? []
           : this.props.workspaceUrlsContext.workspaceUrls.map((url) => ({ url })),

--- a/src/renderer/components/content-types/workspace/TitleBar.tsx
+++ b/src/renderer/components/content-types/workspace/TitleBar.tsx
@@ -9,6 +9,7 @@ import { HypermergeUrl, PushpinUrl } from '../../../ShareLink'
 
 import './TitleBar.css'
 import { useDocument, useEvent } from '../../../Hooks'
+import { WorkspaceUrlsContext } from '../../../WorkspaceHooks'
 
 export interface Props {
   hypermergeUrl: HypermergeUrl
@@ -119,11 +120,16 @@ export default function TitleBar(props: Props) {
           <i className="fa fa-map" />
         </DropdownTrigger>
         <DropdownContent>
-          <Omnibox
-            active={activeOmnibox}
-            hypermergeUrl={props.hypermergeUrl}
-            omniboxFinished={deactivateOmnibox}
-          />
+          <WorkspaceUrlsContext.Consumer>
+            {(workspaceUrlsContext) => (
+              <Omnibox
+                active={activeOmnibox}
+                hypermergeUrl={props.hypermergeUrl}
+                omniboxFinished={deactivateOmnibox}
+                workspaceUrlsContext={workspaceUrlsContext}
+              />
+            )}
+          </WorkspaceUrlsContext.Consumer>
         </DropdownContent>
       </Dropdown>
 

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -22,6 +22,8 @@ import { BoardDoc, CardId } from '../board'
 import { useSystem } from '../../../System'
 import { CurrentDeviceContext } from './Device'
 
+import WorkspaceInList from './WorkspaceInList'
+
 const log = Debug('pushpin:workspace')
 
 export interface Doc {
@@ -233,7 +235,12 @@ ContentTypes.register({
   type: 'workspace',
   name: 'Workspace',
   icon: 'briefcase',
-  contexts: { root: Workspace, 'title-bar': WorkspaceInTitleBar },
+  contexts: {
+    root: Workspace,
+    'title-bar': WorkspaceInTitleBar,
+    list: WorkspaceInList,
+    board: WorkspaceInList,
+  },
   resizable: false,
   unlisted: true,
   create,

--- a/src/renderer/components/content-types/workspace/WorkspaceInList.css
+++ b/src/renderer/components/content-types/workspace/WorkspaceInList.css
@@ -1,0 +1,15 @@
+.WorkspaceLink-Badge {
+  position: relative;
+}
+.WorkspaceLink-ContactOverlay {
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  transform: translate(8px, 8px) scale(0.5);
+}
+
+.WorkspaceLink-words {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/renderer/components/content-types/workspace/WorkspaceInList.tsx
+++ b/src/renderer/components/content-types/workspace/WorkspaceInList.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import Content, { ContentProps } from '../../Content'
+import { useDocument } from '../../../Hooks'
+import Badge from '../../Badge'
+import { Doc } from './Workspace'
+import { createDocumentLink } from '../../../ShareLink'
+import { ContactDoc } from '../contact'
+import Text from '../../Text'
+import SecondaryText from '../../SecondaryText'
+import './WorkspaceInList.css'
+
+export default function WorkspaceListItem(props: ContentProps) {
+  const [doc] = useDocument<Doc>(props.hypermergeUrl)
+  const [selfDoc] = useDocument<ContactDoc>(doc && doc.selfId)
+
+  if (!doc || !selfDoc) {
+    return null
+  }
+
+  const { selfId, viewedDocUrls } = doc
+
+  function onDragStart(e: React.DragEvent) {
+    e.dataTransfer.setData('application/pushpin-url', props.url)
+  }
+
+  return (
+    <div className="DocLink">
+      <div className="WorkspaceLink-Badge" draggable onDragStart={onDragStart}>
+        <Badge icon="briefcase" backgroundColor={selfDoc.color} />
+        <div className="WorkspaceLink-ContactOverlay">
+          <Content url={createDocumentLink('contact', selfId)} context="title-bar" />
+        </div>
+      </div>
+      <div className="DocLink__title">
+        <div className="WorkspaceLink-words">
+          <Text>Workspace for {selfDoc.name}</Text>
+          <SecondaryText>
+            {viewedDocUrls.length} item{viewedDocUrls.length !== 1 ? 's' : ''}
+          </SecondaryText>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Let's get this landed -- we have in here a "WorkspaceInList" widget, a bigger omnibox, and support for having multiple workspaces to switch between.

Not included here:
 - the actual workspace design for omnibox
 - workspace creation (you gotta go get one)
 - organization names for contacts (to help differentiate your workspaces)
 - workspace deletion
 - [known issue] arrow keys don't scroll the workspace to the new highlighted item