### PR TITLE
Online status

### DIFF
--- a/src/renderer/PresenceHooks.ts
+++ b/src/renderer/PresenceHooks.ts
@@ -187,7 +187,7 @@ export function useOnlineDevicesForContact(contactId: HypermergeUrl | null): Pus
 
 export function useContactOnlineStatus(contactId: HypermergeUrl | null): boolean {
   const selfId = useSelfId()
-  const presence = usePresence(contactId)
+  const presence = usePresence(contactId, {}, 'onlineStatus')
   return selfId === contactId || presence.some((p) => p.contact === contactId)
 }
 
@@ -197,8 +197,8 @@ export function useContactOnlineStatus(contactId: HypermergeUrl | null): boolean
  */
 export function useDeviceOnlineStatus(deviceId: HypermergeUrl | null): boolean {
   const currentDeviceUrl = useContext(CurrentDeviceContext)
-  const presence = usePresence(deviceId)
   const isCurrentDevice =
     currentDeviceUrl && parseDocumentLink(currentDeviceUrl).hypermergeUrl === deviceId
+  const presence = usePresence(deviceId, {}, 'onlineStatus')
   return isCurrentDevice || presence.some((p) => p.device === deviceId)
 }

--- a/src/renderer/components/content-types/contact/Avatar.css
+++ b/src/renderer/components/content-types/contact/Avatar.css
@@ -30,7 +30,7 @@
   height: 60px;
 }
 
-.Avatar--online {
+.Avatar--present {
   border: 2px solid var(--highlight-color, var(--colorOnline));
   box-shadow: 0 0 4px 0 var(--highlight-color, var(--colorOnline));
 }

--- a/src/renderer/components/content-types/contact/ContactInVarious.tsx
+++ b/src/renderer/components/content-types/contact/ContactInVarious.tsx
@@ -13,7 +13,7 @@ import Label from '../../Label'
 
 import './ContactInVarious.css'
 import { useSelfId, useDocument } from '../../../Hooks'
-import { useOnlineStatus } from '../../../PresenceHooks'
+import { useContactOnlineStatus } from '../../../PresenceHooks'
 import OwnDeviceConnectionStatus from './OwnDeviceConnectionStatus'
 import ColorBadge from '../../ColorBadge'
 
@@ -31,7 +31,7 @@ export default function ContactInVarious(props: ContentProps) {
     avatarImageDoc || {}
 
   const isSelf = selfId === props.hypermergeUrl
-  const isOnline = useOnlineStatus(props.hypermergeUrl)
+  const isOnline = useContactOnlineStatus(props.hypermergeUrl)
 
   function onDragStart(e: React.DragEvent) {
     e.dataTransfer.setData(
@@ -65,7 +65,7 @@ export default function ContactInVarious(props: ContentProps) {
     <div className="Contact-avatar">
       <a href={props.url}>
         <div
-          className={`Avatar Avatar--${context} Avatar--${isOnline ? 'online' : 'offline'}`}
+          className={`Avatar Avatar--${context}`}
           style={{ ['--highlight-color' as any]: color }}
         >
           {avatarImage}

--- a/src/renderer/components/content-types/workspace/Device.tsx
+++ b/src/renderer/components/content-types/workspace/Device.tsx
@@ -9,7 +9,7 @@ import { useDocument } from '../../../Hooks'
 import Badge from '../../Badge'
 import './Device.css'
 import TitleEditor from '../../TitleEditor'
-import { useOnlineStatusForDevice } from '../../../PresenceHooks'
+import { useDeviceOnlineStatus } from '../../../PresenceHooks'
 
 export interface DeviceDoc {
   icon: string // fa-icon name
@@ -22,7 +22,7 @@ interface Props extends ContentProps {
 
 function Device(props: Props) {
   const [doc] = useDocument<DeviceDoc>(props.hypermergeUrl)
-  const isOnline = useOnlineStatusForDevice(props.hypermergeUrl)
+  const isOnline = useDeviceOnlineStatus(props.hypermergeUrl)
   if (!doc) return null
   const { icon = 'desktop', name } = doc
 

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -11,7 +11,12 @@ import { ContactDoc } from '../contact'
 
 import './Workspace.css'
 import { useDocument } from '../../../Hooks'
-import { useAllHeartbeats, useHeartbeat } from '../../../PresenceHooks'
+import {
+  useAllHeartbeats,
+  useHeartbeat,
+  useContactOnlineStatus,
+  useDeviceOnlineStatus,
+} from '../../../PresenceHooks'
 import { BoardDoc, CardId } from '../board'
 import { useSystem } from '../../../System'
 import { CurrentDeviceContext } from './Device'
@@ -41,11 +46,17 @@ export default function Workspace(props: WorkspaceContentProps) {
   const currentDocUrl = workspace && parseDocumentLink(workspace.currentDocUrl).hypermergeUrl
 
   const [self, changeSelf] = useDocument<ContactDoc>(selfId)
+  const currentDeviceId = currentDeviceUrl
+    ? parseDocumentLink(currentDeviceUrl).hypermergeUrl
+    : null
 
   useAllHeartbeats(selfId)
   useHeartbeat(selfId)
-  useHeartbeat(currentDeviceUrl ? parseDocumentLink(currentDeviceUrl).hypermergeUrl : null)
+  useHeartbeat(currentDeviceId)
   useHeartbeat(currentDocUrl)
+
+  useDeviceOnlineStatus(currentDeviceId)
+  useContactOnlineStatus(selfId)
 
   const sendToSystem = useSystem(
     (msg) => {


### PR DESCRIPTION
Simpler presence-based online-status. Fixes an issue where we weren't correctly checking for remote contact and device online status.

Also removes the presence halo since it wasn't being used correctly. On master, the presence halo/outline is always visible if the contact is online, regardless of what doc they are actually looking it. For now, remove the halo until we can bring back actual presence.