### PR TITLE
Select omnibox text when focusing

### DIFF
--- a/src/renderer/components/content-types/workspace/omnibox/Omnibox.tsx
+++ b/src/renderer/components/content-types/workspace/omnibox/Omnibox.tsx
@@ -30,6 +30,7 @@ export default function Omnibox(props: Props) {
   useEffect(() => {
     if (active && omniboxInput.current) {
       omniboxInput.current.focus()
+      omniboxInput.current.select()
     }
   }, [active])
 


### PR DESCRIPTION
This matches my vim muscle-memory of being able to type `/foo` to get to `foo`, even if i had previously searched for something else.