### PR TITLE
[wip] import images at their natural dimension

### DIFF
--- a/src/renderer/ContentTypes.ts
+++ b/src/renderer/ContentTypes.ts
@@ -1,7 +1,8 @@
 import Debug from 'debug'
 import { ComponentType } from 'react'
 import { Handle } from 'hypermerge'
-import { HypermergeUrl, createDocumentLink } from './ShareLink'
+import { HypermergeUrl, createDocumentLink, PushpinUrl } from './ShareLink'
+import { Dimension } from './components/content-types/board/BoardGrid';
 
 const log = Debug('pushpin:content-types')
 
@@ -26,7 +27,7 @@ interface ContentType {
   resizable?: boolean
   contexts: Contexts
   create?: (typeAttrs: any, handle: Handle<any>, callback: () => void) => void
-  createFromFile?: (file: File, handle: Handle<any>, callback: () => void) => void
+  createFromFile?: (file: File, handle: Handle<any>, callback: (dimension?: Dimension) => void) => void
   supportsMimeType?: (type: string) => boolean
 }
 
@@ -97,15 +98,9 @@ function mimeTypeToContentType(mimeType: string | null): string {
   return supportingType.type
 }
 
-function createFromFile(file, callback): void {
+function createFromFile(file: File, callback: (url: PushpinUrl, dimension?: Dimension) => void): void {
   // normally we just create a file -- but we treat plain-text specially
-  const type = ((mimeType) => {
-    if (mimeType && mimeType.match('text/')) {
-      return 'text'
-    }
-
-    return 'file'
-  })(file.type)
+  const type = file.type && file.type.match('text/') ? 'text' : 'file'
 
   const entry = registry[type]
   if (!entry) {
@@ -118,8 +113,8 @@ function createFromFile(file, callback): void {
 
   const url = window.repo.create() as HypermergeUrl
   const handle = window.repo.open(url)
-  entry.createFromFile(file, handle, () => {
-    callback(createDocumentLink(type, url))
+  entry.createFromFile(file, handle, (dimension?: Dimension) => {
+    callback(createDocumentLink(type, url), dimension)
   })
 }
 

--- a/src/renderer/ImportData.ts
+++ b/src/renderer/ImportData.ts
@@ -1,7 +1,8 @@
 import { isPushpinUrl, PushpinUrl } from './ShareLink'
 import ContentTypes from './ContentTypes'
+import { Dimension } from './components/content-types/board/BoardGrid';
 
-export type CreatedContentCallback = (contentUrl: PushpinUrl, index: number) => void
+export type CreatedContentCallback = (contentUrl: PushpinUrl, index: number, dimension?: Dimension) => void
 
 export function importDataTransfer(dataTransfer: DataTransfer, callback: CreatedContentCallback) {
   const url = dataTransfer.getData('application/pushpin-url')
@@ -62,7 +63,7 @@ function importPlainText(plainText: string, callback: CreatedContentCallback) {
     if (isPushpinUrl(plainText)) {
       callback(plainText, 0)
     } else {
-      determineUrlContents(url, callback)
+      determineUrlContents(url.toString(), callback)
     }
   } catch (e) {
     // i guess it's not a URL after all, we'lll just make a text card
@@ -70,7 +71,7 @@ function importPlainText(plainText: string, callback: CreatedContentCallback) {
   }
 }
 
-function determineUrlContents(url, callback: CreatedContentCallback) {
+function determineUrlContents(url: string, callback: CreatedContentCallback) {
   fetch(url)
     .then((response) => {
       if (!response.ok) throw Error('Fetch failed, just make a URL card.')
@@ -88,7 +89,7 @@ function determineUrlContents(url, callback: CreatedContentCallback) {
       }
       // XXX: come back and look at this
       const file = new File([blob], url, { type: blob.type, lastModified: Date.now() })
-      ContentTypes.createFromFile(file, (contentUrl) => callback(contentUrl, 0))
+      ContentTypes.createFromFile(file, (contentUrl, dimension) => callback(contentUrl, 0, dimension))
     })
     .catch((error) => {
       // this is fine, really -- the URL upgrade to content is optional.

--- a/src/renderer/components/content-types/board/Board.tsx
+++ b/src/renderer/components/content-types/board/Board.tsx
@@ -74,7 +74,7 @@ function Board(props: ContentProps) {
       switch (action.type) {
         // board actions
         case 'AddCardForContent':
-          addAndSelectCard(doc, action.position, action.url, action.selectOnly)
+          addAndSelectCard(doc, action.position, action.dimension, action.url, action.selectOnly)
           break
         case 'ChangeBackgroundColor':
           changeBackgroundColor(doc, action.color)
@@ -125,10 +125,11 @@ function Board(props: ContentProps) {
   function addAndSelectCard(
     doc: BoardDoc,
     position: Position,
+    dimension: Dimension | undefined,
     url: PushpinUrl,
     shouldSelect?: boolean
   ) {
-    const cardId = addCardForContent(doc, { position, url })
+    const cardId = addCardForContent(doc, { position, dimension, url })
     if (shouldSelect) {
       selectOnly(cardId)
     }
@@ -195,9 +196,9 @@ function Board(props: ContentProps) {
         x: pageX - boardRef.current.offsetLeft,
         y: pageY - boardRef.current.offsetTop,
       }
-      ImportData.importDataTransfer(e.dataTransfer, (url, i) => {
+      ImportData.importDataTransfer(e.dataTransfer, (url, i, dimension) => {
         const position = gridOffset(dropPosition, i)
-        dispatch({ type: 'AddCardForContent', position, url })
+        dispatch({ type: 'AddCardForContent', position, url, dimension })
       })
     },
     [dispatch]

--- a/src/renderer/components/content-types/files/index.ts
+++ b/src/renderer/components/content-types/files/index.ts
@@ -11,28 +11,54 @@ import { toNodeReadable } from '../../../../NodeReadable'
 
 const log = Debug('pushpin:filecontent')
 
+interface FileMetadata {
+  naturalWidth?: number
+  naturalHeight?: number
+}
+
 export interface FileDoc {
   title: string // names are editable and not an intrinsic part of the file
   extension: string
   hyperfileUrl: HyperfileUrl
+  metadata?: FileMetadata
+}
+
+async function deriveMetadata(entry: File): Promise<FileMetadata | undefined> {
+  if (entry.type.startsWith('image/')) {
+    const img = new Image
+    img.src = URL.createObjectURL(entry)
+    try {
+      await img.decode()
+      return { naturalWidth: img.naturalWidth, naturalHeight: img.naturalHeight }
+    } catch {
+      return undefined
+    }
+  }
+  return Promise.resolve(undefined)
 }
 
 function createFromFile(entry: File, handle: Handle<FileDoc>, callback) {
   const { name = 'Unnamed File' } = entry
 
-  // XXX: fix this any type
-  const fileStream = toNodeReadable((entry as any).stream())
+  const fileStream = toNodeReadable(entry.stream())
   const mimeType = mime.contentType(entry.type) || 'application/octet-stream'
 
-  Hyperfile.write(fileStream, mimeType)
-    .then(({ url }) => {
+  Promise.all([
+    Hyperfile.write(fileStream, mimeType),
+    deriveMetadata(entry),
+  ])
+    .then(([{ url }, metadata]) => {
       handle.change((doc: FileDoc) => {
         const parsed = path.parse(name)
         doc.hyperfileUrl = url
         doc.title = parsed.name
         doc.extension = parsed.ext.slice(1)
+        doc.metadata = metadata
       })
-      callback()
+      if (metadata && metadata.naturalWidth && metadata.naturalHeight)
+        callback({ width: metadata.naturalWidth, height: metadata.naturalHeight })
+      else
+        callback()
     })
     .catch((err) => {
       log(err)


### PR DESCRIPTION
This is some prep work for having images not be invisible while they're loading. In order for images to be visible during load, we need to know what size they are before we've loaded them. Currently, image cards don't have a height (only the default width of 18 grid cells). This decodes the image when we import it to compute the width & height, and sets the initial card size based on the image's natural dimensions.