### PR TITLE
fix initially invisible images

### DIFF
--- a/src/renderer/components/content-types/board/BoardCard.tsx
+++ b/src/renderer/components/content-types/board/BoardCard.tsx
@@ -246,7 +246,7 @@ function BoardCard(props: BoardCardProps) {
     height: resize ? resize.height : height,
     position: 'absolute',
     willChange: selected ? 'transform' : '',
-    transform: `translate3d(${x}px, ${y}px, 0) translate(var(--drag-x, 0), var(--drag-y, 0))`,
+    transform: `translate(${x}px, ${y}px) translate(var(--drag-x, 0), var(--drag-y, 0))`,
   }
 
   const { type } = parseDocumentLink(url)


### PR DESCRIPTION
this means cards aren't drawn in layers until they're selected, but dragging should still be 60fps since the selection will still push the content into a layer.

i'm pretty sure it should be fine for images to be in a layer though... this smells like a chrome or electron bug underlying the issue.