### PR TITLE
give cards a non-transparent background

### DIFF
--- a/src/renderer/components/content-types/board/BoardCard.css
+++ b/src/renderer/components/content-types/board/BoardCard.css
@@ -7,6 +7,7 @@
   box-sizing: border-box;
   display: flex;
   user-select: none;
+  background: whitesmoke;
 }
 
 .BoardCard:focus,


### PR DESCRIPTION
Combined with #291, this makes images appear as light grey rectangles until they're loaded.