### PR TITLE
Create release builds automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Create Release Builds
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install
+      - run: yarn dist
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            out/*.dmg
+            out/*.exe
+            out/*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,5 +2,14 @@
   "files": ["dist/**/*"],
   "directories": {
     "output": "out"
+  },
+  "mac": {
+    "target": ["dmg"]
+  },
+  "win": {
+    "target": ["nsis"]
+  },
+  "linux": {
+    "target": ["AppImage"]
   }
 }


### PR DESCRIPTION
Uses github actions to automatically create and upload release builds for mac, linux, windows.

Triggered when a tag is pushed that begins with `v`. Creating a new release in the GitHub UI will also create a tag and the workflow will update the release with the packaged binaries.