### PR TITLE
remove automatically generated rules-of-react dependencies that break…

### DIFF
--- a/src/renderer/components/content-types/TextContent.tsx
+++ b/src/renderer/components/content-types/TextContent.tsx
@@ -111,7 +111,7 @@ function useQuill({
       q.off('text-change', onChange)
       // Quill gets garbage collected automatically
     }
-  }, [config, makeChange, selected, textString])
+  }, [ref.current]) // eslint-disable-line
 
   useEffect(() => {
     if (!textString || !quill.current) return


### PR DESCRIPTION
One-liner fix, mostly sharing with you @mjtognetti since I bet it happened with you noticing because of some eslint setting.