### PR TITLE
Fix forward ref errors

### DIFF
--- a/src/renderer/components/Content.tsx
+++ b/src/renderer/components/Content.tsx
@@ -4,10 +4,9 @@ import React, {
   useContext,
   useEffect,
   forwardRef,
+  Ref,
   memo,
   RefForwardingComponent,
-  useImperativeHandle,
-  useRef,
 } from 'react'
 
 import ContentTypes, { Context } from '../ContentTypes'
@@ -23,6 +22,7 @@ export interface ContentProps {
   type: string
   hypermergeUrl: HypermergeUrl
   selfId: HypermergeUrl
+  contentRef?: Ref<ContentHandle>
 }
 
 // These are the props the generic Content wrapper receives
@@ -33,27 +33,13 @@ interface Props {
 }
 
 export interface ContentHandle {
-  onContent: (PushpinUrl) => void
+  onContent: (url: PushpinUrl) => boolean
 }
 
-const Content: RefForwardingComponent<ContentHandle, Props> = (props: Props, ref) => {
-  const contentRef = useRef<any>() // yikes
-  useImperativeHandle(ref, () => ({
-    canReceiveContent: () => {
-      if (contentRef.current && contentRef.current.canReceiveContent) {
-        return contentRef.current.canReceiveContent()
-      }
-      return false
-    },
-    onContent: (url: PushpinUrl) => {
-      if (contentRef.current && contentRef.current.onContent) {
-        return contentRef.current.onContent(url)
-      }
-
-      throw new Error(`no onContent defined for ${ref}`)
-    },
-  }))
-
+const Content: RefForwardingComponent<ContentHandle, Props> = (
+  props: Props,
+  ref: Ref<ContentHandle>
+) => {
   const { context, url } = props
 
   const [isCrashed, setCrashed] = useState(false)
@@ -86,7 +72,7 @@ const Content: RefForwardingComponent<ContentHandle, Props> = (props: Props, ref
     <Crashable onCatch={onCatch}>
       <contentType.component
         {...props}
-        ref={contentRef}
+        contentRef={ref}
         key={url}
         type={type}
         hypermergeUrl={hypermergeUrl}

--- a/src/renderer/components/content-types/board/Board.tsx
+++ b/src/renderer/components/content-types/board/Board.tsx
@@ -1,18 +1,11 @@
-import React, {
-  useRef,
-  useCallback,
-  memo,
-  useMemo,
-  RefForwardingComponent,
-  useImperativeHandle,
-} from 'react'
+import React, { useRef, useCallback, memo, useMemo, useImperativeHandle, SFC } from 'react'
 import Debug from 'debug'
 import { ContextMenuTrigger } from 'react-contextmenu'
 
 import ContentTypes from '../../../ContentTypes'
 import * as ImportData from '../../../ImportData'
 import { PushpinUrl } from '../../../ShareLink'
-import { ContentProps, ContentHandle } from '../../Content'
+import { ContentProps } from '../../Content'
 import { BoardDoc, CardId } from '.'
 import BoardCard, { BoardCardAction } from './BoardCard'
 import BoardContextMenu from './BoardContextMenu'
@@ -71,7 +64,7 @@ export interface AddCardArgs extends CardArgs {
   url: PushpinUrl
 }
 
-const Board: RefForwardingComponent<ContentHandle, ContentProps> = (props: ContentProps) => {
+const Board: SFC<ContentProps> = (props: ContentProps) => {
   useImperativeHandle(props.contentRef, () => ({
     onContent: (url: PushpinUrl) => onContent(url),
   }))

--- a/src/renderer/components/content-types/board/Board.tsx
+++ b/src/renderer/components/content-types/board/Board.tsx
@@ -4,7 +4,6 @@ import React, {
   memo,
   useMemo,
   RefForwardingComponent,
-  forwardRef,
   useImperativeHandle,
 } from 'react'
 import Debug from 'debug'
@@ -72,8 +71,8 @@ export interface AddCardArgs extends CardArgs {
   url: PushpinUrl
 }
 
-const Board: RefForwardingComponent<ContentHandle, ContentProps> = (props: ContentProps, ref) => {
-  useImperativeHandle(ref, () => ({
+const Board: RefForwardingComponent<ContentHandle, ContentProps> = (props: ContentProps) => {
+  useImperativeHandle(props.contentRef, () => ({
     onContent: (url: PushpinUrl) => onContent(url),
   }))
 
@@ -344,4 +343,4 @@ const Board: RefForwardingComponent<ContentHandle, ContentProps> = (props: Conte
   )
 }
 
-export default memo(forwardRef(Board))
+export default memo(Board)

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useContext, useRef } from 'react'
 import Debug from 'debug'
 import uuid from 'uuid'
-import base64 from 'base64-js'
 
 import { parseDocumentLink, PushpinUrl, HypermergeUrl, isPushpinUrl } from '../../../ShareLink'
-import Content, { ContentProps } from '../../Content'
+import Content, { ContentProps, ContentHandle } from '../../Content'
 import ContentTypes, { createFrom } from '../../../ContentTypes'
 import SelfContext from '../../SelfContext'
 import TitleBar from './TitleBar'
@@ -163,7 +162,7 @@ export default function Workspace(props: WorkspaceContentProps) {
     }
   }
 
-  const contentRef = useRef<any>() // hmmm
+  const contentRef = useRef<ContentHandle>(null) // hmmm
 
   function onContent(url: PushpinUrl) {
     if (contentRef.current) {

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -162,7 +162,7 @@ export default function Workspace(props: WorkspaceContentProps) {
     }
   }
 
-  const contentRef = useRef<ContentHandle>(null) // hmmm
+  const contentRef = useRef<ContentHandle>(null)
 
   function onContent(url: PushpinUrl) {
     if (contentRef.current) {


### PR DESCRIPTION
Fixes the forward ref errors popping up in the logs. Fixes them by passing the ref as a prop rather than a standard ref. This positions `Content.tsx` as the ref forwarder. Also includes stricter typing, so if any content types try to use the ref the correct typings will be enforced (in this case,`onContent` will be defined).