### PR TITLE
Respect aspect ratio while filling the avaters entire content box

### DIFF
--- a/src/renderer/components/content-types/contact/Avatar.css
+++ b/src/renderer/components/content-types/contact/Avatar.css
@@ -16,6 +16,7 @@
   height: 100%;
   border-radius: 999px;
   pointer-events: none;
+  object-fit: cover;
 }
 
 .Avatar--title-bar {


### PR DESCRIPTION
Here is before this change with non square image used as avatar:

<img width="229" alt="image" src="https://user-images.githubusercontent.com/21236/67981361-b1275580-fbdd-11e9-8344-3d63602a3dde.png">

And after

<img width="299" alt="image" src="https://user-images.githubusercontent.com/21236/67981374-bbe1ea80-fbdd-11e9-907d-bee369b6a59d.png">
