### PR TITLE
Fix a variety of small omnibox issues

### DIFF
--- a/src/renderer/components/content-types/UrlContent.tsx
+++ b/src/renderer/components/content-types/UrlContent.tsx
@@ -28,6 +28,7 @@ interface UrlData {
 }
 
 interface UrlDoc {
+  title: string
   url: string
   data?: UrlData | { error: string } // TODO: move error to top-level
   htmlHyperfileUrl?: HyperfileUrl
@@ -79,6 +80,11 @@ export default function UrlContent(props: ContentProps) {
     })
   }
   const { data, url, htmlHyperfileUrl, capturedAt } = doc
+
+  if (!doc.title) {
+    // yeesh. this error type is really a pain here.
+    doc.title = data && !('error' in data) && data.title ? data.title : url
+  }
 
   if (!data) {
     return (
@@ -200,6 +206,9 @@ function refreshContent(doc: UrlDoc, change: ChangeFn<UrlDoc>) {
       change((doc: UrlDoc) => {
         removeEmpty(data)
         doc.data = data
+        if (data.title) {
+          doc.title = data.title
+        }
       })
     })
     .catch((reason) => {
@@ -287,13 +296,15 @@ async function createFrom(contentData: ContentData.ContentData, handle: Handle<U
   )
   handle.change((doc) => {
     doc.url = contentData.src! // TODO: we need per-content typing on ContentData
+    doc.title = contentData.src!
     doc.htmlHyperfileUrl = url
   })
 }
 
 function create({ url, src, hyperfileUrl, capturedAt }, handle: Handle<UrlDoc>) {
   handle.change((doc) => {
-    doc.url = url || src
+    doc.url = url || src // XXX: align eleanor and internal creation
+    doc.title = url // XXX: this should also be replaced by an immediate unfluffing
     if (hyperfileUrl) {
       doc.htmlHyperfileUrl = hyperfileUrl
     }

--- a/src/renderer/components/content-types/workspace/TitleBar.tsx
+++ b/src/renderer/components/content-types/workspace/TitleBar.tsx
@@ -105,11 +105,6 @@ export default function TitleBar(props: Props) {
       </button>
       <button type="button" onClick={showOmnibox} className="TitleBar-menuItem">
         <Badge icon="map" backgroundColor="#00000000" />
-        {doc.clips && doc.clips.length > 0 ? (
-          <div className="TitleBar-Map-ColorBadgePlacer">
-            <Badge backgroundColor="#00000000" size="medium" icon="paperclip" />
-          </div>
-        ) : null}
       </button>
 
       <button

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -31,7 +31,6 @@ const log = Debug('pushpin:workspace')
 export interface Doc {
   selfId: HypermergeUrl
   contactIds: HypermergeUrl[]
-  clips: PushpinUrl[] // this is a poor design, but fine(ish) for a POC
   currentDocUrl: PushpinUrl
   viewedDocUrls: PushpinUrl[]
   archivedDocUrls: PushpinUrl[]
@@ -139,10 +138,7 @@ export default function Workspace(props: WorkspaceContentProps) {
   function importClip(payload: any) {
     const creationCallback = (importedUrl) => {
       changeWorkspace((d) => {
-        if (!d.clips) {
-          d.clips = []
-        }
-        d.clips.unshift(importedUrl)
+        d.viewedDocUrls.unshift(importedUrl)
       })
     }
 


### PR DESCRIPTION
A brief list of changes:

 * allows PDFs, files, and other content with .title fields to appear in the Documents list in omnibox
 * adds shift-enter as a shortcut to place content, where enter travels to it
 * removes the .clips concept from the workspace
 * messes up URL Content a little bit more to shoe-horn a title onto it (for now)