### PR TITLE
UrlContent fixes

### DIFF
--- a/src/renderer/components/content-types/UrlContent.css
+++ b/src/renderer/components/content-types/UrlContent.css
@@ -132,6 +132,10 @@
   flex: 1;
 }
 
+.UrlCard-hiddenWebview {
+  display: none;
+}
+
 .UrlCard-img {
   -webkit-user-drag: none;
   height: 192px;

--- a/src/renderer/components/content-types/UrlContent.css
+++ b/src/renderer/components/content-types/UrlContent.css
@@ -108,7 +108,7 @@
 
 .UrlListItem-icon {
   height: 40px;
-  margin: 0 8px 0 8px;
+  margin-left: 8px;
   -webkit-user-drag: none;
   display: block;
   object-fit: cover;
@@ -119,6 +119,7 @@
   flex-direction: column;
   font-family: IBM Plex Sans;
   font-size: 10px;
+  margin-left: 8px;
   line-height: 1.2;
   color: #637389;
   justify-self: flex-end;

--- a/src/renderer/components/content-types/UrlContent.tsx
+++ b/src/renderer/components/content-types/UrlContent.tsx
@@ -69,7 +69,6 @@ export default function UrlContent(props: ContentProps) {
     return null
   }
 
-  console.log(doc.data)
   function refreshContent() {
     changeDoc((doc) => {
       delete doc.htmlHyperfileUrl

--- a/src/renderer/components/content-types/UrlContent.tsx
+++ b/src/renderer/components/content-types/UrlContent.tsx
@@ -197,6 +197,9 @@ async function unfluffContent(doc: UrlDoc, change: ChangeFn<UrlDoc>) {
 
   change((doc: UrlDoc) => {
     doc.data = data
+    if (data.title) {
+      doc.title = data.title
+    }
     if (data.image) {
       fetchImageContent(doc, change)
     }


### PR DESCRIPTION
URL content wasn't unfluffing clipped URLs and wasn't storing pasted ones. Now it does both.

There's more work to do in here with restructuring the render functions to reduce brain damage, but this is a start.