### PR TITLE
clean up avatar sizing in the titlebar

### DIFF
--- a/src/renderer/components/Badge.tsx
+++ b/src/renderer/components/Badge.tsx
@@ -27,7 +27,7 @@ export default React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) =
     <div
       ref={ref}
       className={`Badge Badge--${size} Badge--${shape} ${img ? 'Badge--image' : null}`}
-      style={{ backgroundColor, backgroundImage: `url(${img})` }}
+      style={{ backgroundColor, backgroundImage: img ? `url(${img})` : undefined }}
     >
       <i className={`fa fa-${icon}`} />
     </div>

--- a/src/renderer/components/content-types/contact/Avatar.css
+++ b/src/renderer/components/content-types/contact/Avatar.css
@@ -4,8 +4,9 @@
   justify-content: center;
   box-sizing: border-box;
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: 33px;
+  height: 33px;
+
   border-radius: 999px;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.27);
   padding: 2px;
@@ -20,8 +21,8 @@
 }
 
 .Avatar--title-bar {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   padding: 1px;
 }
 

--- a/src/renderer/components/content-types/contact/ContactInVarious.tsx
+++ b/src/renderer/components/content-types/contact/ContactInVarious.tsx
@@ -107,11 +107,7 @@ export default function ContactInVarious(props: ContentProps) {
       )
 
     case 'title-bar':
-      return (
-        <div draggable onDragStart={onDragStart}>
-          {avatar}
-        </div>
-      )
+      return <ContentDragHandle url={url}>{avatar}</ContentDragHandle>
 
     case 'board':
       return (

--- a/src/renderer/components/content-types/workspace/TitleBar.css
+++ b/src/renderer/components/content-types/workspace/TitleBar.css
@@ -62,34 +62,9 @@ button[disabled].TitleBar-menuItem .fa {
   color: var(--colorBlueBlack);
 }
 
-.TitleBar-right .dropdown__trigger {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-}
-
-.TitleBar-right .dropdown.dropdown--active {
-  background-color: var(--colorInputGrey);
-}
-
-.TitleBar-right .dropdown__content {
-  top: 48px;
-  right: 0px;
-}
-
-.TitleBar-left .dropdown__content {
-  left: 0px;
-  top: 48px;
-}
-
-.TitleBar-logo {
-  margin-right: 8px;
-}
-
 .TitleBar-self {
   padding-left: 4px;
+  border-left: 1px solid var(--colorSecondaryGrey);
 }
 
 @keyframes color-flash {


### PR DESCRIPTION
A few little avatar CSS tweaks. I basically hate everything going on with avatar sizing here, but I haven't got a plan for what to do instead. If these look (visually) okay to you let's land them and then have a conversation about how to rewrite this so it's less awful. (Rebuilding the Avatar to use badge might help, for example?)