### PR TITLE
put a double-click action onto the avatar

### DIFF
--- a/src/renderer/components/content-types/contact/ContactInVarious.tsx
+++ b/src/renderer/components/content-types/contact/ContactInVarious.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import Debug from 'debug'
+import classNames from 'classnames'
 
 import Content, { ContentProps } from '../../Content'
 import { ContactDoc } from '.'
 
-import { createDocumentLink, HypermergeUrl } from '../../../ShareLink'
+import { createDocumentLink } from '../../../ShareLink'
 import { DEFAULT_AVATAR_PATH } from '../../../constants'
 
 import './ContactInVarious.css'
@@ -15,7 +16,6 @@ import ColorBadge from '../../ColorBadge'
 import ListItem from '../../ListItem'
 import ContentDragHandle from '../../ContentDragHandle'
 import TitleWithSubtitle from '../../TitleWithSubtitle'
-import classNames from 'classnames'
 import CenteredVerticalStack from '../../CenteredVerticalStack'
 import Heading from '../../Heading'
 
@@ -51,8 +51,13 @@ export default function ContactInVarious(props: ContactProps) {
     <img alt="avatar" src={DEFAULT_AVATAR_PATH} />
   )
 
+  const onDoubleClick = (e: React.MouseEvent) => {
+    window.location.href = url as string
+    e.stopPropagation()
+  }
+
   const avatar = (
-    <div className="Contact-avatar">
+    <div className="Contact-avatar" onDoubleClick={onDoubleClick}>
       <div
         className={classNames('Avatar', `Avatar--${context}`, isPresent && 'Avatar--present')}
         style={{ ['--highlight-color' as any]: color }}


### PR DESCRIPTION
It was incorrectly navigating on single-click (it was wrapped in an `<a href=""/>` element) so I removed that but then realized nothing was covering navigation on the title-bar during yesterday's user test.

This is now fixed, but maybe a bit aggressively by making all avatars double-clickable. I think it's *okay* - on board it's already double-clickable anywhere on the card, and in the omnibox it will navigate on single click so it will never come up -- but it's not ideal.