### PR TITLE
Unregister from storage peer when peer removed as device

### DIFF
--- a/src/renderer/Misc.ts
+++ b/src/renderer/Misc.ts
@@ -1,12 +1,4 @@
 import * as Automerge from 'automerge'
-import { RepoFrontend } from 'hypermerge'
-import { HypermergeUrl } from './ShareLink'
-
-export function getDoc<T>(repo: RepoFrontend, url: HypermergeUrl): Promise<Automerge.Doc<T>> {
-  return new Promise((res, rej) => {
-    repo.doc<T>(url, res)
-  })
-}
 
 /**
  * Helper function for removing an item from an Automerge list.

--- a/src/renderer/Misc.ts
+++ b/src/renderer/Misc.ts
@@ -1,0 +1,19 @@
+import * as Automerge from 'automerge'
+import { RepoFrontend } from 'hypermerge'
+import { HypermergeUrl } from './ShareLink'
+
+export function getDoc<T>(repo: RepoFrontend, url: HypermergeUrl): Promise<Automerge.Doc<T>> {
+  return new Promise((res, rej) => {
+    repo.doc<T>(url, res)
+  })
+}
+
+/**
+ * Helper function for removing an item from an Automerge list.
+ */
+export function without<T>(val: T, list: Automerge.List<T>) {
+  const pos = list.findIndex((item) => item === val)
+  if (!pos) return
+  // The Automerge type for deleteAt is wrong.
+  list.deleteAt!(pos)
+}

--- a/src/renderer/components/content-types/contact/ContactEditorDevice.tsx
+++ b/src/renderer/components/content-types/contact/ContactEditorDevice.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback } from 'react'
+import { Doc } from 'automerge'
+import { PushpinUrl, parseDocumentLink, HypermergeUrl } from '../../../ShareLink'
+import { useDocument, ChangeFn } from '../../../Hooks'
+import Content from '../../Content'
+import ActionListItem from '../workspace/omnibox/ActionListItem'
+import { DeviceDoc } from '../workspace/Device'
+import { StoragePeerDoc } from '../storage-peer'
+import './ContactEditor.css'
+
+export interface Props {
+  selfUrl: HypermergeUrl
+  deviceId: PushpinUrl
+  isCurrentDevice: boolean
+  onRemoveDevice: (url: PushpinUrl) => void
+}
+
+export default function ContactEditorDevice(props: Props) {
+  const { selfUrl, deviceId, onRemoveDevice, isCurrentDevice } = props
+  const { hypermergeUrl: deviceHypermergeUrl } = parseDocumentLink(deviceId)
+  const [deviceDoc, changeDevice] = useDocument<DeviceDoc>(deviceHypermergeUrl)
+
+  const removeDevice = useCallback(() => {
+    // XXX: We want to unregister from the storage peer when we remove it as a device.
+    // We need a better way to do this, but for now just hack it here.
+    if (isStoragePeer(deviceDoc)) {
+      unregisterFromStoragePeer(changeDevice as ChangeFn<StoragePeerDoc>, selfUrl)
+    }
+    onRemoveDevice(deviceId)
+  }, [deviceDoc, changeDevice, selfUrl, deviceId, onRemoveDevice])
+
+  if (!deviceDoc) {
+    return null
+  }
+
+  // XXX: Would be better to not recreate this every render.
+  const deviceActions = [
+    {
+      name: 'remove',
+      destructive: true,
+      callback: () => () => removeDevice(),
+      faIcon: 'fa-trash',
+      label: 'Remove',
+      shortcut: '⌘+⌫',
+      keysForActionPressed: (e: KeyboardEvent) => (e.metaKey || e.ctrlKey) && e.key === 'Backspace',
+    },
+  ]
+
+  return (
+    <ActionListItem
+      contentUrl={deviceId}
+      actions={isCurrentDevice ? [] : deviceActions}
+      selected={false}
+    >
+      <Content context="list" url={deviceId} editable />
+    </ActionListItem>
+  )
+}
+
+function isStoragePeer(doc: unknown): doc is Doc<StoragePeerDoc> {
+  return !!(doc as any).registry
+}
+
+function unregisterFromStoragePeer(
+  changeStoragePeer: ChangeFn<StoragePeerDoc>,
+  contactUrl: HypermergeUrl
+) {
+  changeStoragePeer((doc) => {
+    delete doc.registry[contactUrl]
+  })
+}

--- a/src/renderer/components/content-types/storage-peer/StoragePeerHooks.ts
+++ b/src/renderer/components/content-types/storage-peer/StoragePeerHooks.ts
@@ -1,11 +1,12 @@
 import { useCallback, useContext } from 'react'
 import { RepoFrontend, DocUrl, Crypto } from 'hypermerge'
-import Automerge, { FreezeObject } from 'automerge'
+import { FreezeObject } from 'automerge'
 import { StoragePeerDoc } from '.'
 import { useRepo, useDocument, useSelfId } from '../../../Hooks'
 import { WorkspaceUrlsContext } from '../../../WorkspaceHooks'
 import { ContactDoc } from '../contact'
 import { parseDocumentLink } from '../../../ShareLink'
+import { without } from '../../../Misc'
 
 export type RegistrationFn = () => void
 export type UnregistrationFn = () => void
@@ -74,14 +75,4 @@ async function getVerifiedEncryptionKey(
     message: doc.encryptionKey,
     signature: doc.encryptionKeySignature,
   })
-}
-
-/**
- * Helper function for removing an item from an Automerge list.
- */
-function without<T>(val: T, list: Automerge.List<T>) {
-  const pos = list.findIndex((item) => item === val)
-  if (!pos) return
-  // The Automerge type for deleteAt is wrong.
-  list.deleteAt!(pos)
 }


### PR DESCRIPTION
This is a little rough - the logic for removing a storage peer is duplicated in `ContactEditor.tsx`. Ideally, we would only define this once