### PR TITLE
fix crash when attempting to render old storage peer docs

### DIFF
--- a/src/renderer/components/content-types/storage-peer/StoragePeer.tsx
+++ b/src/renderer/components/content-types/storage-peer/StoragePeer.tsx
@@ -26,7 +26,7 @@ export default function StoragePeer(props: ContentProps) {
 
   const { context, url, hypermergeUrl } = props
   const { name, registry } = doc
-  const countRegistered = Object.keys(registry).length
+  const countRegistered = Object.keys(registry || {}).length
 
   const title = name
   const subtitle = `${countRegistered} stored workspace${countRegistered === 1 ? '' : 's'}`

--- a/src/renderer/components/content-types/storage-peer/StoragePeerHooks.ts
+++ b/src/renderer/components/content-types/storage-peer/StoragePeerHooks.ts
@@ -26,7 +26,7 @@ export function useStoragePeer(
   const currentWorkspace = workspaceUrlsContext && workspaceUrlsContext.workspaceUrls[0]
   const workspaceUrl = currentWorkspace && parseDocumentLink(currentWorkspace).hypermergeUrl
 
-  const isRegistered = doc && !!doc.registry[selfId]
+  const isRegistered = doc && doc.registry && !!doc.registry[selfId]
 
   const register = useCallback(async () => {
     if (!doc || !workspaceUrl || isRegistered) return


### PR DESCRIPTION
e.g.

```
Uncaught TypeError: Cannot read property 'hypermerge:/7BDQurR6xZvswbdMSgmQR9bR3bK6phb1cnryMDGyGpFE' of undefined
    at Object.useStoragePeer (StoragePeerHooks.ts:27)
    at StoragePeer (StoragePeer.tsx:20)
    [...]
```