### PR TITLE
Don't wrap title of BoardInBoard

### DIFF
--- a/src/renderer/components/Heading.css
+++ b/src/renderer/components/Heading.css
@@ -4,6 +4,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 100%;
 }
 
 .Heading--wrap {

--- a/src/renderer/components/content-types/board/BoardInBoard.tsx
+++ b/src/renderer/components/content-types/board/BoardInBoard.tsx
@@ -33,7 +33,7 @@ export default function BoardInBoard(props: ContentProps) {
     <div className="BoardInBoard BoardCard--standard">
       <CenteredStack>
         <Badge size="huge" icon="files-o" backgroundColor={backgroundColor} />
-        <Heading wrap>{title}</Heading>
+        <Heading>{title}</Heading>
         <SecondaryText>{subTitle}</SecondaryText>
       </CenteredStack>
     </div>


### PR DESCRIPTION
Also fix <Heading> to properly elide text with ellipsis.

Before
<img width="196" alt="PushPin" src="https://user-images.githubusercontent.com/172800/69498858-421de380-0ea1-11ea-9081-031af5a775a4.png">

After
<img width="200" alt="PushPin" src="https://user-images.githubusercontent.com/172800/69498838-1569cc00-0ea1-11ea-914a-299ff2a89ec9.png">
