### PR TITLE
Reflect board selection in the titlebar

### DIFF
--- a/src/renderer/components/TitleEditor.css
+++ b/src/renderer/components/TitleEditor.css
@@ -1,6 +1,12 @@
 .TitleEditor {
-  font-size: 14px;
-  line-height: 20px;
-  width: 100%;
+  font-size: 1.25em;
   padding: 0px; /* someone (me?) put padding on all inputs */
+}
+
+/* use hidden text to cause title editor
+input expand with typed text */
+span.TitleEditor {
+  visibility: hidden;
+  z-index: -1;
+  height: 0px;
 }

--- a/src/renderer/components/TitleEditor.tsx
+++ b/src/renderer/components/TitleEditor.tsx
@@ -46,17 +46,22 @@ export default function TitleEditor(props: Props) {
     return null
   }
 
+  // span below input ensures that outer element is resized according
+  // to the content causing input field also grow with it.
   return (
-    <input
-      ref={input}
-      draggable={preventDrag}
-      onDragStart={onDragStart}
-      type="text"
-      className="TitleEditor"
-      value={doc[field]}
-      placeholder={placeholder}
-      onKeyDown={onKeyDown}
-      onChange={onChange}
-    />
+    <>
+      <input
+        ref={input}
+        draggable={preventDrag}
+        onDragStart={onDragStart}
+        type="text"
+        className="TitleEditor"
+        value={doc[field]}
+        placeholder={placeholder}
+        onKeyDown={onKeyDown}
+        onChange={onChange}
+      />
+      <span className="TitleEditor">{doc[field]}</span>
+    </>
   )
 }

--- a/src/renderer/components/content-types/TextContent.tsx
+++ b/src/renderer/components/content-types/TextContent.tsx
@@ -216,6 +216,7 @@ ContentTypes.register({
     board: TextContent,
     workspace: TextContent,
     list: TextInList,
+    'title-bar': TextInList,
   },
   create,
   createFrom,

--- a/src/renderer/components/content-types/ThreadContent.tsx
+++ b/src/renderer/components/content-types/ThreadContent.tsx
@@ -4,6 +4,10 @@ import * as ContentTypes from '../../ContentTypes'
 import Content, { ContentProps } from '../Content'
 import { createDocumentLink, HypermergeUrl } from '../../ShareLink'
 import { useDocument } from '../../Hooks'
+import ListItem from '../ui/ListItem'
+import Badge from '../ui/Badge'
+import ContentDragHandle from '../ui/ContentDragHandle'
+import TitleWithSubtitle from '../ui/TitleWithSubtitle'
 import './ThreadContent.css'
 
 interface Message {
@@ -13,6 +17,7 @@ interface Message {
 }
 
 interface Doc {
+  title?: string
   messages: Message[]
 }
 
@@ -88,6 +93,31 @@ export default function ThreadContent(props: ContentProps) {
   )
 }
 
+export function ThreadInList(props: ContentProps) {
+  const { hypermergeUrl, url } = props
+  const [doc] = useDocument<Doc>(hypermergeUrl)
+  if (!doc) return null
+
+  const title = doc.title != null && doc.title !== '' ? doc.title : 'Untitled conversation'
+  const subtitle = (doc.messages[doc.messages.length - 1] || { content: '' }).content
+  const editable = true
+
+  return (
+    <ListItem>
+      <ContentDragHandle url={url}>
+        <Badge icon={icon} />
+      </ContentDragHandle>
+      <TitleWithSubtitle
+        titleEditorField="title"
+        title={title}
+        subtitle={subtitle}
+        hypermergeUrl={hypermergeUrl}
+        editable={editable}
+      />
+    </ListItem>
+  )
+}
+
 function stopPropagation(e: React.SyntheticEvent) {
   e.stopPropagation()
   e.nativeEvent.stopImmediatePropagation()
@@ -136,13 +166,17 @@ function create(unusedAttrs, handle) {
   })
 }
 
+const icon = 'comments'
+
 ContentTypes.register({
   type: 'thread',
   name: 'Thread',
-  icon: 'comments',
+  icon,
   contexts: {
     workspace: ThreadContent,
     board: ThreadContent,
+    list: ThreadInList,
+    'title-bar': ThreadInList,
   },
   create,
 })

--- a/src/renderer/components/content-types/UrlContent.tsx
+++ b/src/renderer/components/content-types/UrlContent.tsx
@@ -306,6 +306,7 @@ ContentTypes.register({
     workspace: UrlContent,
     board: UrlContent,
     list: UrlContent,
+    'title-bar': UrlContent,
   },
   create,
   createFrom,

--- a/src/renderer/components/content-types/board/Board.css
+++ b/src/renderer/components/content-types/board/Board.css
@@ -3,3 +3,30 @@
   background-image: url('../../../images/grid.svg');
   background-blend-mode: exclusion;
 }
+
+.ActiveCard {
+  overflow: hidden;
+  margin: 0 3px;
+  border-radius: 16px;
+  box-shadow: -6px 1px 3px -3px rgba(0, 0, 0, 0.3);
+  background: inherit;
+  flex: 1;
+  border-radius: 25px;
+  margin-left: -6px;
+  padding: 2px;
+  background: inherit;
+}
+
+.BoardSelection {
+  display: flex;
+  flex-flow: row;
+  background: inherit;
+}
+
+.BoardSelection .ActiveCard:not(:first-child) {
+  margin-left: -16px;
+}
+
+.BoardSelection .Badge {
+  --size: 22px;
+}

--- a/src/renderer/components/content-types/board/Board.tsx
+++ b/src/renderer/components/content-types/board/Board.tsx
@@ -69,7 +69,9 @@ const Board: FunctionComponent<ContentProps> = (props: ContentProps) => {
   }))
 
   const boardRef = useRef<HTMLDivElement>(null)
-  const { selection, selectOnly, selectToggle, selectNone } = useSelection<CardId>()
+  const { selection, selectOnly, selectToggle, selectNone } = useSelection<CardId>(
+    props.hypermergeUrl
+  )
 
   const [doc, dispatch] = useDocumentReducer<BoardDoc, BoardAction>(
     props.hypermergeUrl,

--- a/src/renderer/components/content-types/board/BoardCard.css
+++ b/src/renderer/components/content-types/board/BoardCard.css
@@ -49,6 +49,10 @@
   background-origin: content-box;
   cursor: se-resize;
   visibility: hidden;
+
+  /* Card content might use z-index as well so use high
+    index here to avoid resizer being covered.*/
+  z-index: 999;
 }
 
 .BoardCard:hover .BoardCard-resizeHandle {

--- a/src/renderer/components/content-types/board/BoardInBoard.tsx
+++ b/src/renderer/components/content-types/board/BoardInBoard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { ContentProps } from '../../Content'
-import { BoardDoc } from '.'
+import { BoardDoc, icon } from '.'
 import { useDocument } from '../../../Hooks'
 import './BoardInBoard.css'
 import Badge from '../../ui/Badge'
@@ -30,7 +30,7 @@ export default function BoardInBoard(props: ContentProps) {
 
   return (
     <CenteredStack>
-      <Badge size="huge" icon="files-o" backgroundColor={backgroundColor} />
+      <Badge size="huge" icon={icon} backgroundColor={backgroundColor} />
       <Heading wrap>{title}</Heading>
       <SecondaryText>{subTitle}</SecondaryText>
     </CenteredStack>

--- a/src/renderer/components/content-types/board/BoardInList.tsx
+++ b/src/renderer/components/content-types/board/BoardInList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BoardDoc } from '.'
+import { BoardDoc, icon } from '.'
 import { ContentProps } from '../../Content'
 import { useDocument } from '../../../Hooks'
 import Badge, { Props as BadgeProps } from '../../ui/Badge'
@@ -20,7 +20,6 @@ export default function BoardInList(props: Props) {
   }
 
   const { title, backgroundColor, cards } = doc
-  const icon = 'files-o'
 
   const cardLength = Object.keys(cards).length
   const subtitle = `${cardLength} item${cardLength !== 1 ? 's' : ''}`

--- a/src/renderer/components/content-types/board/BoardInTitleBar.tsx
+++ b/src/renderer/components/content-types/board/BoardInTitleBar.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { BoardDoc, BoardDocCard, CardId, icon } from '.'
+import Content, { ContentProps } from '../../Content'
+import { useDocument } from '../../../Hooks'
+import { useSelection } from './BoardSelection'
+import Badge from '../../ui/Badge'
+import CardBadge from './CardBadge'
+import ListItem from '../../ui/ListItem'
+import TitleWithSubtitle from '../../ui/TitleWithSubtitle'
+import ContentDragHandle from '../../ui/ContentDragHandle'
+
+interface Props extends ContentProps {
+  editable: boolean
+}
+
+type KeyedCard = [CardId, BoardDocCard]
+
+export default function BoardInTitleBar(props: Props) {
+  const { hypermergeUrl } = props
+  const [doc] = useDocument<BoardDoc>(hypermergeUrl)
+  const { selection } = useSelection<CardId>(hypermergeUrl)
+
+  if (!doc) {
+    return null
+  }
+
+  return selection.length === 0
+    ? Board(props, doc)
+    : BoardSelection(props, doc, selectedCards(selection, doc.cards))
+}
+
+const selectedCards = <K extends string, V>(
+  selection: string[],
+  cards: { [id: string]: V }
+): [K, V][] => (Object.entries(cards) as [K, V][]).filter(([id]) => selection.includes(id))
+
+const Board = (
+  { url, hypermergeUrl, editable }: Props,
+  { title, backgroundColor, cards }: BoardDoc
+) => {
+  const items = Object.entries(cards)
+  const subtitle = `${items.length} item${items.length !== 1 ? 's' : ''}`
+  return (
+    <ListItem>
+      <ContentDragHandle url={url}>
+        <Badge icon={icon} backgroundColor={backgroundColor} />
+      </ContentDragHandle>
+      <TitleWithSubtitle
+        title={title}
+        subtitle={subtitle}
+        hypermergeUrl={hypermergeUrl}
+        editable={editable}
+      />
+    </ListItem>
+  )
+}
+
+export const BoardBadge = (props: Props) => {
+  const { hypermergeUrl, url } = props
+  const [doc] = useDocument<BoardDoc>(hypermergeUrl)
+
+  if (!doc) {
+    return null
+  }
+
+  return (
+    <ContentDragHandle url={url}>
+      <Badge icon={icon} backgroundColor={doc.backgroundColor} />
+    </ContentDragHandle>
+  )
+}
+
+const BoardSelection = (props: Props, doc: BoardDoc, selectedCards: KeyedCard[]) =>
+  selectedCards.length === 1
+    ? ActiveBoardItem(props, doc, selectedCards[0])
+    : SelectedBoardItems(props, doc, selectedCards)
+
+const ActiveBoardItem = (
+  { url, hypermergeUrl, editable }: Props,
+  { title, backgroundColor }: BoardDoc,
+  [id, card]: KeyedCard
+) => {
+  return (
+    <ListItem>
+      <ContentDragHandle url={url}>
+        <Badge icon={icon} backgroundColor={backgroundColor} />
+      </ContentDragHandle>
+      <div className="ActiveCard">
+        <Content url={card.url} context="list" editable />
+      </div>
+    </ListItem>
+  )
+}
+
+const SelectedBoardItems = (
+  { url, hypermergeUrl, editable, context }: Props,
+  { title, backgroundColor }: BoardDoc,
+  selectedCards: KeyedCard[]
+) => {
+  const subtitle = `${selectedCards.length} items selected`
+  return (
+    <ListItem>
+      <ContentDragHandle url={url}>
+        <Badge icon={icon} backgroundColor={backgroundColor} />
+      </ContentDragHandle>
+      <div className="BoardSelection">
+        {selectedCards.map(([id, card]) => (
+          <div className="ActiveCard" key={id}>
+            <CardBadge url={card.url} context={context} />
+          </div>
+        ))}
+      </div>
+      <TitleWithSubtitle
+        title={title}
+        subtitle={subtitle}
+        hypermergeUrl={hypermergeUrl}
+        editable={editable}
+      />
+    </ListItem>
+  )
+}

--- a/src/renderer/components/content-types/board/BoardSelection.ts
+++ b/src/renderer/components/content-types/board/BoardSelection.ts
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import { useStaticCallback } from '../../../Hooks'
+import { useStaticCallback, useSharedState } from '../../../Hooks'
 
 export type Selection<T> = T[]
 
@@ -7,16 +6,18 @@ export type Selection<T> = T[]
  * Selection manipulation functions
  * these functional control the currently selected set of cards
  */
-export function useSelection<T>(): {
+export function useSelection<T>(
+  id: string
+): {
   selection: Selection<T>
   selectToggle: (id: T) => void
   selectOnly: (id: T) => void
   selectNone: () => void
 } {
-  const [selection, setSelection] = useState<T[]>([])
+  const [selection, setSelection] = useSharedState<T[]>(id, [])
 
   const selectToggle = useStaticCallback((id: T) =>
-    setSelection((selected) =>
+    setSelection((selected: T[]) =>
       selected.includes(id) ? selected.filter((filterId) => filterId !== id) : [...selected, id]
     )
   )

--- a/src/renderer/components/content-types/board/CardBadge.tsx
+++ b/src/renderer/components/content-types/board/CardBadge.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Doc } from 'hypermerge'
+import { parseDocumentLink, PushpinUrl } from '../../../ShareLink'
+import * as ContentTypes from '../../../ContentTypes'
+import Badge from '../../ui/Badge'
+import { useDocument } from '../../../Hooks'
+import ContentDragHandle from '../../ui/ContentDragHandle'
+
+interface Props {
+  url: PushpinUrl
+  context: ContentTypes.Context
+}
+
+export default (props: Props) => {
+  const { url, context } = props
+  const { type, hypermergeUrl } = parseDocumentLink(url)
+  const [doc] = useDocument<Doc<{ backgroundColor?: string }>>(hypermergeUrl)
+
+  if (!doc) {
+    return null
+  }
+
+  const contentType = ContentTypes.lookup({ type, context })
+
+  const icon = contentType ? contentType.icon : 'exclamation-triangle'
+
+  return (
+    <ContentDragHandle url={url}>
+      <Badge icon={icon} backgroundColor={doc.backgroundColor} />
+    </ContentDragHandle>
+  )
+}

--- a/src/renderer/components/content-types/board/index.ts
+++ b/src/renderer/components/content-types/board/index.ts
@@ -5,6 +5,7 @@ import * as ContentTypes from '../../../ContentTypes'
 import Board, { BOARD_COLORS } from './Board'
 import BoardInBoard from './BoardInBoard'
 import BoardInList from './BoardInList'
+import BoardInTitleBar from './BoardInTitleBar'
 import { HypermergeUrl, PushpinUrl } from '../../../ShareLink'
 
 export type CardId = string & { cardId: true }
@@ -52,14 +53,17 @@ function create(typeAttrs, handle) {
   initializeBoard(typeAttrs, handle)
 }
 
+export const icon = 'sitemap'
+
 ContentTypes.register({
   type: 'board',
   contexts: {
     workspace: Board,
     board: BoardInBoard,
     list: BoardInList,
+    'title-bar': BoardInTitleBar,
   },
   name: 'Board',
-  icon: 'copy',
+  icon,
   create,
 })

--- a/src/renderer/components/content-types/files/ImageContent.tsx
+++ b/src/renderer/components/content-types/files/ImageContent.tsx
@@ -83,6 +83,7 @@ ContentTypes.register({
     workspace: ImageContent,
     board: ImageContent,
     list: ImageInList,
+    'title-bar': ImageInList,
   },
   supportsMimeType,
 })

--- a/src/renderer/components/content-types/files/index.ts
+++ b/src/renderer/components/content-types/files/index.ts
@@ -46,6 +46,7 @@ ContentTypes.register({
     workspace: FileContent,
     board: FileContent,
     list: FileContent,
+    'title-bar': FileContent,
   },
   create,
   createFrom,

--- a/src/renderer/components/content-types/storage-peer/index.ts
+++ b/src/renderer/components/content-types/storage-peer/index.ts
@@ -26,5 +26,6 @@ ContentTypes.register({
     workspace: StoragePeerWorkspace,
     board: StoragePeer,
     list: StoragePeer,
+    'title-bar': StoragePeer,
   },
 })

--- a/src/renderer/components/content-types/workspace/TitleBar.css
+++ b/src/renderer/components/content-types/workspace/TitleBar.css
@@ -13,6 +13,17 @@
   background-color: white;
 }
 
+.TitleBar .ContentHeader {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  background: inherit;
+}
+
+.Inline {
+  display: inline-flex;
+}
+
 button[disabled].TitleBar-menuItem .fa {
   color: #ccc;
 }

--- a/src/renderer/components/content-types/workspace/TitleBar.tsx
+++ b/src/renderer/components/content-types/workspace/TitleBar.tsx
@@ -95,30 +95,38 @@ export default function TitleBar(props: Props) {
 
   return (
     <div className="TitleBar">
-      <button disabled={backDisabled} type="button" onClick={goBack} className="TitleBar-menuItem">
-        <i className="fa fa-angle-left" />
-      </button>
-      <button type="button" onClick={showOmnibox} className="TitleBar-menuItem">
-        <Badge icon="map" backgroundColor="#00000000" />
-      </button>
+      <div className="NavigationBar Inline">
+        <button
+          disabled={backDisabled}
+          type="button"
+          onClick={goBack}
+          className="TitleBar-menuItem"
+        >
+          <i className="fa fa-angle-left" />
+        </button>
+        <button type="button" onClick={showOmnibox} className="TitleBar-menuItem">
+          <Badge icon="search" backgroundColor="#00000000" />
+        </button>
 
-      <button
-        disabled={forwardDisabled}
-        type="button"
-        onClick={goForward}
-        className="TitleBar-menuItem"
-      >
-        <i className="fa fa-angle-right" />
-      </button>
-
-      <div className="TitleBar-content">
-        <Content url={doc.currentDocUrl} context="list" editable />
+        <button
+          disabled={forwardDisabled}
+          type="button"
+          onClick={goForward}
+          className="TitleBar-menuItem"
+        >
+          <i className="fa fa-angle-right" />
+        </button>
       </div>
-      <Authors currentDocUrl={doc.currentDocUrl} workspaceUrl={props.hypermergeUrl} />
-      <div className="TitleBar-self">
-        <Content url={createDocumentLink('contact', doc.selfId)} context="title-bar" isPresent />
-      </div>
 
+      <div className="ContentHeader Group">
+        <Content url={doc.currentDocUrl} context="title-bar" editable />
+      </div>
+      <div className="CollaboratorsBar Inline">
+        <Authors currentDocUrl={doc.currentDocUrl} workspaceUrl={props.hypermergeUrl} />
+        <div className="TitleBar-self">
+          <Content url={createDocumentLink('contact', doc.selfId)} context="title-bar" isPresent />
+        </div>
+      </div>
       <button
         className="BoardTitle__clipboard BoardTitle__labeledIcon TitleBar-menuItem"
         type="button"

--- a/src/renderer/components/content-types/workspace/Workspace.tsx
+++ b/src/renderer/components/content-types/workspace/Workspace.tsx
@@ -300,6 +300,7 @@ ContentTypes.register({
     root: Workspace,
     list: WorkspaceInList,
     board: WorkspaceInList,
+    'title-bar': WorkspaceInList,
   },
   resizable: false,
   unlisted: true,

--- a/src/renderer/components/ui/ListItem.css
+++ b/src/renderer/components/ui/ListItem.css
@@ -1,6 +1,8 @@
 .ListItem {
   display: flex;
+  flex: 1;
   flex-direction: row;
   align-items: center;
-  width: 100%;
+  overflow: hidden;
+  background: inherit;
 }

--- a/src/renderer/components/ui/TitleWithSubtitle.css
+++ b/src/renderer/components/ui/TitleWithSubtitle.css
@@ -10,5 +10,4 @@
   text-overflow: ellipsis;
   flex-shrink: 0;
   flex: auto;
-  width: 0px;
 }

--- a/src/renderer/components/ui/TitleWithSubtitle.tsx
+++ b/src/renderer/components/ui/TitleWithSubtitle.tsx
@@ -30,7 +30,7 @@ export default function TitleWithSubtitle(props: Props) {
   return (
     <div className="TitleWithSubtitle">
       {editable ? (
-        <TitleEditor field={titleEditorField} url={hypermergeUrl} />
+        <TitleEditor field={titleEditorField} placeholder={title} url={hypermergeUrl} />
       ) : (
         <Heading wrap={wrapTitle}>{title}</Heading>
       )}


### PR DESCRIPTION
Implementation of #336. In this version pull is entangled with bunch of other pulls I've submitted, but if things look good I'll rework it to only contain relevant changes.

P.S: I still think that showing board badge when 1 card is selected is kind of pointless & just creates a noise.

## No cards selected
<img width="991" alt="Screen Shot 2019-12-05 at 12 58 02 PM" src="https://user-images.githubusercontent.com/21236/70273717-880b5f00-175f-11ea-84f6-e921cf05462d.png">

## A card is selected
<img width="991" alt="Screen Shot 2019-12-05 at 12 57 56 PM" src="https://user-images.githubusercontent.com/21236/70273714-880b5f00-175f-11ea-8c88-023c68953197.png">

## Multiple cards are selected
<img width="988" alt="image" src="https://user-images.githubusercontent.com/21236/70304338-9173e600-17b6-11ea-917f-dc9b289dcfb7.png">
